### PR TITLE
新增 Go 假日 CLI、可分享 Agent Skill、跨平台發布安裝與公開查詢網站

### DIFF
--- a/.github/skills/query-taiwan-holiday/SKILL.md
+++ b/.github/skills/query-taiwan-holiday/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: query-taiwan-holiday
+description: Query Taiwan holiday or workday status for a specific date. Use for date-specific holiday questions, automation or scheduling checks, and requests for structured Taiwan holiday data.
+---
+
+# Query Taiwan Holiday
+
+## Query
+
+1. Require one exact ASCII ISO date (`YYYY-MM-DD`). Reject whitespace, timestamps, slashes, impossible dates, and values that do not round-trip through a calendar-aware date parser.
+2. Prefer the installed CLI for structured output:
+
+   ```sh
+   holidaybook --json YYYY-MM-DD
+   ```
+
+   Use `holidaybook YYYY-MM-DD` for a concise human-readable answer. Add `--base-url https://mirror.example` to either form when a trusted mirror is required.
+3. If `holidaybook` is unavailable, request the validated date directly:
+
+   ```sh
+   curl --fail-with-body --silent --show-error --location \
+     --proto '=https' --tlsv1.2 --connect-timeout 10 --max-time 30 \
+     'https://holiday.gh.miniasp.com/YYYY-MM-DD.json'
+   ```
+
+   Substitute only the already validated date; keep the URL quoted. Do not disable TLS verification.
+4. Parse JSON rather than scraping text. Require one object, a matching `date` (the API may use `YYYYMMDD`), and a present, recognized `isHoliday` value.
+
+## Interpret
+
+- Treat `isHoliday: true` or `1` as a holiday.
+- Treat `isHoliday: false` or `0` as a workday.
+- Do not infer status from weekday/weekend alone; Taiwan can designate weekend workdays (`補行上班日`) and compensatory holidays.
+- The two sources use different field shapes for the same data:
+  - `holidaybook --json`: `date` is `YYYY-MM-DD`, `isHoliday` is a boolean, and the category field is `category`.
+  - Static JSON (`https://holiday.gh.miniasp.com/YYYY-MM-DD.json`): `date` is `YYYYMMDD`, `isHoliday` is `0`/`1`, and the category field is `holidaycategory`.
+- Preserve useful structured fields: `date`, `name`, the category field for that source, and `description`. Workdays can also carry them (for example 軍人節 is `isHoliday` false with a name and description). For automation, return the raw or requested JSON shape instead of prose unless asked.
+- Treat missing, null, or unrecognized `isHoliday` as unknown data, never as a workday.
+
+## Handle failures
+
+- On a nonzero CLI or curl exit, report retrieval failure and make no holiday-status claim.
+- CLI exit codes: `0` success, `2` bad arguments or invalid date, `1` runtime failure. With `--json`, failures print `{"error":{"code":"...","message":"..."}}` on stderr, where `code` is one of `usage`, `invalid_date`, `invalid_configuration`, `http_error`, `invalid_response`, `timeout`, `canceled`, `network_error`, `output_error`.
+- Distinguish HTTP 404 or unavailable data from DNS, TLS, timeout, and other transport errors when stderr provides that detail.
+- Reject malformed JSON, non-object responses, date mismatches, and missing required fields explicitly.
+- Never silently substitute a nearby date or guess from the calendar.

--- a/.github/skills/query-taiwan-holiday/agents/openai.yaml
+++ b/.github/skills/query-taiwan-holiday/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Taiwan Holiday Query"
+  short_description: "Query Taiwan holiday and workday status"
+  default_prompt: "Use $query-taiwan-holiday to check whether a specific Taiwan date is a holiday or workday and return structured data."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "ci-${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  go-quality:
+    name: Go quality and delivery checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify formatting
+        shell: bash
+        run: |
+          unformatted="$(git ls-files '*.go' | xargs gofmt -l)"
+          if [[ -n "${unformatted}" ]]; then
+            printf 'The following files need gofmt:\n%s\n' "${unformatted}"
+            exit 1
+          fi
+
+      - name: Run Go tests
+        run: go test ./...
+
+      - name: Run Go vet
+        run: go vet ./...
+
+      - name: Check POSIX installer syntax
+        run: bash -n install.sh
+
+      - name: Check PowerShell installer syntax
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $parseErrors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path "./install.ps1"),
+            [ref] $tokens,
+            [ref] $parseErrors
+          ) | Out-Null
+          if ($parseErrors.Count -gt 0) {
+            $parseErrors | ForEach-Object { Write-Error $_ }
+            exit 1
+          }
+
+      - name: Validate GoReleaser configuration
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: check
+
+  cross-build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: darwin
+            goarch: amd64
+            extension: ""
+          - goos: darwin
+            goarch: arm64
+            extension: ""
+          - goos: linux
+            goarch: amd64
+            extension: ""
+          - goos: linux
+            goarch: arm64
+            extension: ""
+          - goos: windows
+            goarch: amd64
+            extension: .exe
+          - goos: windows
+            goarch: arm64
+            extension: .exe
+    env:
+      CGO_ENABLED: "0"
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+      OUTPUT_NAME: holidaybook${{ matrix.extension }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Cross-build CLI
+        run: go build -trimpath -ldflags="-X main.version=ci" -o "${RUNNER_TEMP}/${OUTPUT_NAME}" ./cmd/holidaybook
+
+  dotnet-tests:
+    name: .NET generator tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Test static generator
+        run: dotnet test StaticGenerator.Tests/StaticGenerator.Tests.csproj --configuration Release --verbosity normal

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,37 +2,51 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ master ]
-    paths: [ 'docs/**' ]
+    branches:
+      - master
+    paths:
+      - "public/**"
+      - "docs/*.json"
+      - ".github/workflows/deploy-pages.yml"
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
   deploy:
+    name: Deploy static site and holiday data
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Assemble Pages site
+        shell: bash
+        run: |
+          mkdir -p _site
+          cp -R public/. _site/
+          find docs -maxdepth 1 -type f -name '*.json' -exec cp '{}' _site/ \;
+          test -f _site/index.html
+          test "$(cat _site/CNAME)" = "holiday.gh.miniasp.com"
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          path: 'docs'
+          path: _site
+
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/generate-data.yml
+++ b/.github/workflows/generate-data.yml
@@ -7,37 +7,35 @@ name: Generate Holiday Data
 on:
   schedule:
     # Run daily at 2 AM UTC (10 AM Taiwan time)
-    - cron: '0 2 * * *'
-  workflow_dispatch: # Allow manual trigger
+    - cron: "0 2 * * *"
+  workflow_dispatch:
   push:
-    branches: [ master ]
-    paths: 
-      - 'StaticGenerator/**'
-      - '.github/workflows/generate-data.yml'
+    branches:
+      - master
+    paths:
+      - "StaticGenerator/**"
+      - ".github/workflows/generate-data.yml"
 
-# Grant GITHUB_TOKEN the permissions required to push to the repository
 permissions:
   contents: write
 
 jobs:
   generate-data:
     runs-on: ubuntu-latest
-    
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
-          # Use PAT to trigger other workflows when pushing changes
-          # Falls back to GITHUB_TOKEN if PAT is not available
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          # Use PAT to trigger the Pages workflow, falling back to GITHUB_TOKEN.
+          token: ${{ secrets.PAT || github.token }}
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 8.0.x
 
       - name: Cache .NET dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
@@ -66,48 +64,59 @@ jobs:
         run: |
           cd StaticGenerator
           dotnet run --configuration Release
-          echo "generation_successful=true" >> $GITHUB_OUTPUT
         continue-on-error: true
 
       - name: Commit and push changes
-        if: steps.generate.outputs.generation_successful == 'true'
+        if: steps.generate.outcome == 'success'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add docs/
-          
-          # Check if there are changes to commit
+
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
             git commit -m "Auto-update holiday data - $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
-            # Push with PAT to trigger deploy-pages.yml workflow
             git push
           fi
 
       - name: Send error notification
-        if: steps.generate.outputs.generation_successful != 'true'
+        if: always() && steps.generate.outcome == 'failure'
+        env:
+          FROM_EMAIL: ${{ secrets.FROM_EMAIL }}
+          NOTIFICATION_EMAIL: ${{ secrets.NOTIFICATION_EMAIL }}
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
         run: |
-          if [ -n "${{ secrets.SENDGRID_API_KEY }}" ] && [ -n "${{ secrets.NOTIFICATION_EMAIL }}" ]; then
-            curl -X "POST" "https://api.sendgrid.com/v3/mail/send" \
-              -H "Authorization: Bearer ${{ secrets.SENDGRID_API_KEY }}" \
+          if [ -n "${SENDGRID_API_KEY}" ] && [ -n "${NOTIFICATION_EMAIL}" ]; then
+            timestamp="$(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+            from_email="${FROM_EMAIL:-noreply@github.com}"
+            curl --fail-with-body --request POST "https://api.sendgrid.com/v3/mail/send" \
+              -H "Authorization: Bearer ${SENDGRID_API_KEY}" \
               -H "Content-Type: application/json" \
-              -d '{
-                "personalizations": [
-                  {
-                    "to": [{"email": "${{ secrets.NOTIFICATION_EMAIL }}"}],
-                    "subject": "❌ Holiday Data Generation Failed"
-                  }
-                ],
-                "from": {"email": "${{ secrets.FROM_EMAIL || 'noreply@github.com' }}"},
-                "content": [
-                  {
-                    "type": "text/html",
-                    "value": "<h2>❌ Holiday Data Generation Failed</h2><p><strong>Repository:</strong> ${{ github.repository }}</p><p><strong>Workflow:</strong> ${{ github.workflow }}</p><p><strong>Run ID:</strong> ${{ github.run_id }}</p><p><strong>Time:</strong> $(date -u +\"%Y-%m-%d %H:%M:%S UTC\")</p><p><strong>Details:</strong> <a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View workflow run</a></p>"
-                  }
-                ]
-              }'
+              --data @- <<EOF
+          {
+            "personalizations": [
+              {
+                "to": [{"email": "${NOTIFICATION_EMAIL}"}],
+                "subject": "❌ Holiday Data Generation Failed"
+              }
+            ],
+            "from": {"email": "${from_email}"},
+            "content": [
+              {
+                "type": "text/html",
+                "value": "<h2>❌ Holiday Data Generation Failed</h2><p><strong>Repository:</strong> ${{ github.repository }}</p><p><strong>Workflow:</strong> ${{ github.workflow }}</p><p><strong>Run ID:</strong> ${{ github.run_id }}</p><p><strong>Time:</strong> ${timestamp}</p><p><strong>Details:</strong> <a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View workflow run</a></p>"
+              }
+            ]
+          }
+          EOF
             echo "Error notification email sent"
           else
             echo "SendGrid API key or notification email not configured, skipping email notification"
           fi
+
+      - name: Fail workflow after generation failure
+        if: always() && steps.generate.outcome == 'failure'
+        run: |
+          echo "Holiday data generation failed; see the Generate holiday data step for details." >&2
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release CLI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "release-${{ github.ref }}"
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Publish release
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,8 @@ StaticGenerator/test-data.json
 # Test coverage reports
 StaticGenerator.Tests/TestResults/
 StaticGenerator.Tests/coverage/
+
+# Go CLI build output
+/dist/
+/holidaybook
+/holidaybook.exe

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,44 @@
+version: 2
+
+project_name: holidaybook
+
+builds:
+  - id: holidaybook
+    main: ./cmd/holidaybook
+    binary: holidaybook
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - ids:
+      - holidaybook
+    name_template: "holidaybook_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+changelog:
+  use: github-native
+
+release:
+  draft: false
+  prerelease: auto

--- a/README.md
+++ b/README.md
@@ -1,98 +1,228 @@
-# Taiwan Holiday Static Site
+# Holidaybook - 台灣假日速查
 
-這是一個專門用來提供台灣假日資訊的靜態網站專案，假期的資料來源是[臺北市資料大平臺](https://data.taipei/)的[臺北市政府行政機關辦公日曆表](https://data.taipei/dataset/detail?id=c30ca421-d935-4faa-b523-9c175c8de738)資料。
+Holidaybook 提供台灣假日資訊的完整取用方式：一個自訂網域的網頁 UI、一套靜態 JSON API、一支給人與 AI 代理人使用的 Go CLI，以及一份可分享的 repository skill。所有資料都是每日、每月、每年自動產生的靜態 JSON 檔案，來源是[臺北市資料大平臺](https://data.taipei/)的[臺北市政府行政機關辦公日曆表](https://data.taipei/dataset/detail?id=c30ca421-d935-4faa-b523-9c175c8de738)。
 
-本專案使用 GitHub Actions 每日自動更新假期資料，並通過 GitHub Pages 提供靜態 JSON API 服務。
+## 網站與 JSON API
 
-## Basic Usage
+主要網域是 `https://holiday.gh.miniasp.com`（由 GitHub Pages 搭配 `public/CNAME` 提供自訂網域服務）。網站本身提供查詢介面，同一份資料也可以直接以靜態 JSON 存取：
 
-查詢特定日期的假期資訊，只需要訪問對應的 JSON 檔案：
+- 單日查詢：`https://holiday.gh.miniasp.com/{YYYY-MM-DD}.json`
+  例如 `https://holiday.gh.miniasp.com/2025-10-10.json`
+- 月份查詢（回傳當月每一天的物件陣列）：`https://holiday.gh.miniasp.com/{YYYY-MM}.json`
+  例如 `https://holiday.gh.miniasp.com/2025-10.json`
+- 年度查詢（回傳當年每一天的物件陣列）：`https://holiday.gh.miniasp.com/{YYYY}.json`
+  例如 `https://holiday.gh.miniasp.com/2025.json`
 
-### 單日查詢
+單日 JSON 範例：
 
-- 格式: `https://doggy8088.github.io/holidaybook/{YYYY-MM-DD}.json`
-- 範例: `https://doggy8088.github.io/holidaybook/2025-07-20.json`
+```json
+{"_id":1529,"date":"20251010","name":"國慶日","isHoliday":1,"holidaycategory":"放假之紀念日及節日","description":"全國各機關學校放假一日。"}
+```
 
-### 月份查詢
+> 靜態 API 的日期欄位是 `YYYYMMDD`（不含連字號），假別欄位名稱是 `holidaycategory`；下方的 CLI 會把它們正規化成較好用的欄位名稱。
 
-查詢特定月份的所有假期資訊：
+## 安裝 CLI
 
-- 格式: `https://doggy8088.github.io/holidaybook/{YYYY-MM}.json`
-- 範例: `https://doggy8088.github.io/holidaybook/2025-09.json`
+CLI 目前僅透過 GitHub Releases 發布可執行檔（不提供 Homebrew、apt、winget 等套件管理員安裝方式）。
 
-### 年度查詢
+### macOS / Linux
 
-查詢特定年度的所有假期資訊：
+以 `install.sh` 下載最新版並安裝到 `~/.local/bin`（若 `HOME` 未設定則需自行指定 `--dir`）：
 
-- 格式: `https://doggy8088.github.io/holidaybook/{YYYY}.json`
-- 範例: `https://doggy8088.github.io/holidaybook/2025.json`
+```sh
+curl -fsSL https://raw.githubusercontent.com/doggy8088/holidaybook/master/install.sh | sh
+```
 
-## Remark
+指定版本或安裝目錄（也可用環境變數 `HOLIDAYBOOK_INSTALL_DIR` 取代 `--dir`）：
 
-有一些特殊節日不是所有人都放假：
+```sh
+curl -fsSL https://raw.githubusercontent.com/doggy8088/holidaybook/master/install.sh | sh -s -- --version v0.1.0 --dir "$HOME/bin"
+```
 
-1. 軍人節
+已 clone 專案時，也可以直接在本機執行腳本：
 
-    只有軍人才放假！本系統已將軍人節設定為非假日 (`isHoliday`: 0)。
+```sh
+git clone https://github.com/doggy8088/holidaybook.git
+cd holidaybook
+sh install.sh --version v0.1.0 --dir "$HOME/bin"
+```
 
-2. 勞動節
+安裝完成後，若安裝目錄已在 `PATH` 中，腳本會提示直接執行 `holidaybook --help`；否則會提示先把該目錄加入 `PATH`。
 
-    只有勞工才放假！
+### Windows
 
-## 資料更新
+以 `install.ps1` 下載最新版，預設安裝到 `%LOCALAPPDATA%\Programs\holidaybook`：
 
-- 資料每日透過 GitHub Actions 自動更新
-- 資料範圍：從 2024-01-01 開始，涵蓋未來 3 年 (到 2026 年底)
-- 如果 API 獲取失敗，會透過 SendGrid 發送錯誤通知郵件
+```powershell
+irm https://raw.githubusercontent.com/doggy8088/holidaybook/master/install.ps1 | iex
+```
 
-### GitHub Actions 設定
+指定版本或安裝目錄時，建議先下載腳本再帶參數執行（`-Version`、`-InstallDir`）：
 
-為了讓資料更新後自動部署到 GitHub Pages，需要設定一個 Personal Access Token (PAT)：
+```powershell
+git clone https://github.com/doggy8088/holidaybook.git
+cd holidaybook
+./install.ps1 -Version v0.1.0 -InstallDir "$HOME\bin"
+```
 
-1. 前往 GitHub Settings > Developer settings > Personal access tokens > Tokens (classic)
-2. 產生一個新的 token，勾選 `repo` 權限
-3. 在此專案的 Settings > Secrets and variables > Actions 中新增名為 `PAT` 的 secret
-4. 將產生的 token 填入 secret 值
+安裝完成後，若安裝目錄已在 `PATH` 中可直接執行 `holidaybook --help`；否則腳本會提示加入 `PATH`，或直接以完整路徑執行 `& "<InstallDir>\holidaybook.exe" --help`。
 
-沒有 PAT 的話，`generate-data.yml` 工作流程推送變更後不會觸發 `deploy-pages.yml` 工作流程。
+## CLI 使用方式
 
-## Development
+人類可讀輸出：
 
-### 本地測試靜態產生器
+```console
+$ holidaybook 2025-10-10
+2025-10-10：放假（國慶日）
+類別：放假之紀念日及節日
+說明：全國各機關學校放假一日。
 
-1. Download
+$ holidaybook 2025-10-14
+2025-10-14：上班日
+
+$ holidaybook 2025-09-03
+2025-09-03：上班日（軍人節）
+類別：特定節日
+說明：軍人依國防部規定辦理。
+```
+
+機器可讀輸出（`--json`，方便串接腳本或代理人）：
+
+```console
+$ holidaybook --json 2025-10-10
+{"date":"2025-10-10","isHoliday":true,"name":"國慶日","category":"放假之紀念日及節日","description":"全國各機關學校放假一日。"}
+
+$ holidaybook --json 2025-10-14
+{"date":"2025-10-14","isHoliday":false,"name":"","category":"","description":""}
+```
+
+### 參數
+
+| 參數 | 說明 |
+| --- | --- |
+| `--json` | 輸出機器可讀 JSON（成功與錯誤都會是 JSON），適合腳本與代理人使用 |
+| `--base-url URL` | 覆寫預設來源網域，預設為 `https://holiday.gh.miniasp.com` |
+| `--timeout DURATION` | 覆寫連線逾時時間（Go duration 格式，例如 `10s`），預設 10 秒 |
+| `--version` | 印出目前版本後結束 |
+| `--help`（或 `-h`） | 印出用法後結束 |
+
+參數與日期參數（`YYYY-MM-DD`）可以任意前後順序混用。若自訂網域尚未生效，可加上 `--base-url https://doggy8088.github.io/holidaybook` 直接查詢 GitHub Pages 上的同一份資料。
+
+### 錯誤與結束碼（適合寫腳本判斷）
+
+- `0`：查詢成功
+- `2`：命令列參數錯誤（例如缺少日期、日期格式錯誤、`--base-url`／`--timeout` 設定無效、`--help`/`--version` 帶了多餘參數）
+- `1`：執行期錯誤（連線逾時、網路錯誤、HTTP 非 2xx、回應內容不合法、查詢被中斷）
+
+錯誤一律輸出到 stderr；加上 `--json` 時錯誤也會是 JSON，格式為 `{"error":{"code":"...","message":"..."}}`，`code` 可能是 `usage`、`invalid_date`、`invalid_configuration`、`http_error`、`invalid_response`、`timeout`、`canceled`、`network_error`、`output_error` 之一。查無資料的日期（超出資料範圍）會是 HTTP 404，也就是 `http_error`。
+
+## 給 AI 代理人使用
+
+CLI 的 `--json` 輸出是穩定的代理人介面，欄位固定為：
+
+- `date`：`YYYY-MM-DD`
+- `isHoliday`：布林值
+- `name`：假期或節日名稱（沒有對應名稱時為空字串）
+- `category`：假別，例如「星期六、星期日」「放假之紀念日及節日」「補行上班日」（沒有時為空字串）
+- `description`：說明文字（沒有時為空字串）
+
+上班日不一定所有欄位都是空的：補班日會有 `category`，軍人節則同時有 `name` 與 `description`。
+
+> 注意：CLI 輸出的欄位是 `category`；若直接讀取靜態 JSON API（`docs/*.json` / `https://holiday.gh.miniasp.com/*.json`），該欄位名稱是 `holidaycategory`，且 `date` 是 `YYYYMMDD`、`isHoliday` 是 `0`/`1` 整數。
+
+### Repository skill
+
+專案內建可分享的 agent skill：[`.github/skills/query-taiwan-holiday`](.github/skills/query-taiwan-holiday/SKILL.md)（含 `SKILL.md` 查詢/錯誤處理慣例，以及 `agents/openai.yaml` 介面中繼資料）。任何支援 repository skills 的代理人都可以直接載入使用，範例提示（取自 `agents/openai.yaml` 的 `default_prompt`）：
+
+> Use `$query-taiwan-holiday` to check whether a specific Taiwan date is a holiday or workday and return structured data.
+
+該 skill 的行為：優先使用已安裝的 `holidaybook --json YYYY-MM-DD`；若 CLI 不可用，才 fallback 到直接 `curl` 靜態 JSON（`https://holiday.gh.miniasp.com/YYYY-MM-DD.json`），並要求代理人解析 JSON 而非用文字比對、日期需先驗證為合法的 `YYYY-MM-DD`、查詢失敗時明確回報而不臆測。
+
+## 假日資料的注意事項
+
+- 不要用「星期六、星期日」自行推論放假狀態；請一律以資料中的 `isHoliday` 為準（台灣有補班日與補假日，週末不一定等於放假、平日也不一定等於上班）。
+- 上班日也可能帶有資訊：例如補班日的 `holidaycategory`／`category` 是「補行上班日」，軍人節則是 `isHoliday` 為否、但仍有 `name` 與 `description`。
+- 超出來源日曆表已公告範圍的日期（通常是尚未公告的年度）會先產生為正常上班日，實際放假規則仍以政府公告為準。
+- 有些節日不是所有人都放假：
+  1. **軍人節**：只有軍人才放假，本系統已將軍人節設定為非假日（`isHoliday` 為 `0`／`false`）。
+  2. **勞動節**：只有勞工才放假。
+
+## 開發
+
+### Go CLI
+
+```sh
+gofmt -l $(git ls-files '*.go')   # 檢查格式（有輸出代表需要 gofmt）
+go test ./...                    # 執行單元測試
+go vet ./...                     # 靜態檢查
+go build -o holidaybook ./cmd/holidaybook   # 建置執行檔
+```
+
+### .NET 8 靜態產生器
+
+1. 下載專案
 
     ```sh
     git clone https://github.com/doggy8088/holidaybook.git
     cd holidaybook
     ```
 
-2. 執行靜態產生器
+2. 還原、建置、測試
+
+    ```sh
+    cd StaticGenerator && dotnet restore
+    cd ../StaticGenerator.Tests && dotnet restore
+    cd ../StaticGenerator && dotnet build --configuration Release --no-restore
+    cd ../StaticGenerator.Tests && dotnet test --configuration Release --no-restore --verbosity normal
+    ```
+
+3. 產生資料（會清空並重建 `docs/`）
 
     ```sh
     cd StaticGenerator
-    dotnet run
+    dotnet run --configuration Release
     ```
 
-3. 查看產生的檔案
+4. 查看產生的檔案
 
     ```sh
     ls docs/
-    cat docs/2025-09-28.json
+    cat docs/2025-10-10.json
     ```
 
-### GitHub Actions 設定
+`StaticGenerator/appsettings.json` 目前設定：
 
-需要在 Repository Secrets 中設定以下變數（用於錯誤通知）：
+- `DataSource.ApiUrl`：臺北市資料大平臺開放資料 API
+- `DataSource.TestDataPath`：API 失敗時的備援資料檔 `test-data.json`（未包含於此 repository，需自行提供）
+- `Generation.OutputDirectory`：`../docs`
+- `Generation.StartDate`：`2024-01-01`
+- `Generation.YearsToGenerate`：`2`（每次執行時，結束日期＝執行當下起算未來 2 年，並非固定年份；因此資料涵蓋範圍會隨執行時間往後推進）
 
-- `SENDGRID_API_KEY`: SendGrid API 金鑰
-- `NOTIFICATION_EMAIL`: 接收錯誤通知的信箱
-- `FROM_EMAIL`: 發送錯誤通知的信箱（可選，預設為 noreply@github.com）
+## CI/CD
 
-## DataSource
+- **PR CI 與 master push**（`.github/workflows/ci.yml`）：對 Pull Request、push 到 `master` 或手動觸發時執行 `gofmt` 格式檢查、`go test ./...`、`go vet ./...`、`install.sh` 語法檢查（`bash -n`）、`install.ps1` 語法檢查（PowerShell parser）、`goreleaser check`、macOS／Linux／Windows × amd64／arm64 六種組合的交叉建置，以及 `.NET` 產生器單元測試。
+- **發布**（`.github/workflows/release.yml`）：推送符合 `v*` 的 tag 時觸發，先跑 `go test ./...`，再用 [GoReleaser](.goreleaser.yml) 建置並發布 GitHub Release，產出 macOS／Linux／Windows（amd64／arm64）共 6 組壓縮檔（`holidaybook_<os>_<arch>.tar.gz`，Windows 為 `.zip`）與 `checksums.txt`（SHA-256），`install.sh`／`install.ps1` 都會下載並驗證這份 checksum。維護者發布新版時，建立並推送一個帶註解的 tag 即可觸發，例如：
 
-- API
-  - 2024~2026 所有假期的網址:
-    - <https://data.taipei/api/v1/dataset/0dcbcfcf-f7a1-4664-a810-82c01cb524e0?scope=resourceAquire&offset=1316&limit=1000>
+  ```sh
+  git tag -a v0.1.0 -m "holidaybook v0.1.0"
+  git push origin v0.1.0
+  ```
+
+- **每日資料更新**（`.github/workflows/generate-data.yml`）：每天 UTC 02:00（台灣時間上午 10 點）以及手動觸發時執行，還原、建置、測試並執行 `StaticGenerator`，若 `docs/` 有變更就自動 commit 並 push；產生失敗時，若已設定 SendGrid 相關 secrets 會寄出通知信，並讓該次工作流程回報失敗。
+- **GitHub Pages 部署**（`.github/workflows/deploy-pages.yml`）：`public/**`、`docs/*.json` 有變更或手動觸發時執行，將 `public/` 內容與 `docs/` 下的頂層 `*.json` 檔案一起組成 `_site/`，確認 `index.html` 與 `CNAME`（內容需為 `holiday.gh.miniasp.com`）存在後，部署到 GitHub Pages。
+
+### GitHub Actions 所需設定
+
+- `PAT`：具備 `repo` 權限的 Personal Access Token，供 `generate-data.yml` 用來推送變更；沒有設定時會 fallback 使用預設的 `GITHUB_TOKEN`，但用 `GITHUB_TOKEN` 推送不會觸發 `deploy-pages.yml`，需改用手動觸發或設定 `PAT`。
+- `SENDGRID_API_KEY`、`NOTIFICATION_EMAIL`：設定後，資料產生失敗時會透過 SendGrid 寄出錯誤通知信；`FROM_EMAIL`（可選，預設為 `noreply@github.com`）。未設定這兩個必要 secrets 時只會在 log 中略過寄信，不影響失敗回報。
+
+## GitHub Pages 自訂網域
+
+網站以 `public/CNAME`（內容為 `holiday.gh.miniasp.com`）設定 GitHub Pages 的自訂網域；`deploy-pages.yml` 會在部署前驗證這個檔案內容正確無誤。要讓網域生效，需在 DNS 供應商為 `holiday.gh.miniasp.com` 設定指向 GitHub Pages 的 `CNAME` 紀錄，並在 repository 的 Pages 設定中啟用該自訂網域與 HTTPS。
+
+## 資料來源
+
+- API：2024～2028 年（依執行當下持續往後延伸）所有假期的網址：
+  - <https://data.taipei/api/v1/dataset/0dcbcfcf-f7a1-4664-a810-82c01cb524e0?scope=resourceAquire&offset=1316&limit=1000>
 - [臺北市資料大平臺](https://data.taipei/)
   - [臺北市政府行政機關辦公日曆表](https://data.taipei/dataset/detail?id=c30ca421-d935-4faa-b523-9c175c8de738)

--- a/cmd/holidaybook/main.go
+++ b/cmd/holidaybook/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"github.com/doggy8088/holidaybook/internal/cli"
+)
+
+var version = "dev"
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	code := cli.Run(ctx, os.Args[1:], os.Stdout, os.Stderr, version)
+	stop()
+	os.Exit(code)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/doggy8088/holidaybook
+
+go 1.23

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,157 @@
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string] $Version = "latest",
+
+    [Parameter()]
+    [string] $InstallDir = (Join-Path ([Environment]::GetFolderPath("LocalApplicationData")) "Programs\holidaybook")
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+$repository = "doggy8088/holidaybook"
+$program = "holidaybook"
+
+function Stop-Installer {
+    param([string] $Message)
+    throw "holidaybook installer: $Message"
+}
+
+function Test-WindowsHost {
+    # Windows PowerShell (5.1) only runs on Windows; PowerShell 6+ exposes $IsWindows.
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        return $true
+    }
+    return [bool] $IsWindows
+}
+
+function Get-TargetArchitecture {
+    $osArchitecture = $null
+    try {
+        # Available on .NET Framework 4.7.1+ and PowerShell 6+; reports the OS (not process) architecture.
+        $osArchitecture = [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+    }
+    catch {
+        $osArchitecture = $null
+    }
+    if ([string]::IsNullOrWhiteSpace($osArchitecture)) {
+        $osArchitecture = $env:PROCESSOR_ARCHITEW6432
+    }
+    if ([string]::IsNullOrWhiteSpace($osArchitecture)) {
+        $osArchitecture = $env:PROCESSOR_ARCHITECTURE
+    }
+
+    switch -Regex ($osArchitecture) {
+        '^(X64|AMD64)$' { return "amd64" }
+        '^ARM64$' { return "arm64" }
+        default { Stop-Installer "unsupported architecture: $osArchitecture; use amd64 or arm64" }
+    }
+}
+
+if (-not (Test-WindowsHost)) {
+    Stop-Installer "this installer supports Windows only"
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    Stop-Installer "Version cannot be empty"
+}
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    Stop-Installer "InstallDir cannot be empty"
+}
+
+$architecture = Get-TargetArchitecture
+
+$archive = "${program}_windows_${architecture}.zip"
+if ($Version -eq "latest") {
+    $releaseUrl = "https://github.com/$repository/releases/latest/download"
+}
+else {
+    $tag = if ($Version.StartsWith("v")) { $Version } else { "v$Version" }
+    $releaseUrl = "https://github.com/$repository/releases/download/$tag"
+}
+
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+    # Windows PowerShell may default to TLS 1.0/1.1, which GitHub rejects.
+    [Net.ServicePointManager]::SecurityProtocol =
+        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+}
+
+try {
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+}
+catch {
+    Stop-Installer "cannot create '$InstallDir'; choose a writable path with -InstallDir"
+}
+
+$workDir = Join-Path $InstallDir ".$program-install-$PID-$([Guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Path $workDir | Out-Null
+
+try {
+    $archivePath = Join-Path $workDir $archive
+    $checksumsPath = Join-Path $workDir "checksums.txt"
+
+    Write-Host "Downloading $program (windows/$architecture)..."
+    try {
+        Invoke-WebRequest -UseBasicParsing -Uri "$releaseUrl/$archive" -OutFile $archivePath
+        Invoke-WebRequest -UseBasicParsing -Uri "$releaseUrl/checksums.txt" -OutFile $checksumsPath
+    }
+    catch {
+        Stop-Installer "download failed from GitHub Releases: $($_.Exception.Message)"
+    }
+
+    $escapedArchive = [Regex]::Escape($archive)
+    $checksumLine = Get-Content $checksumsPath |
+        Where-Object { $_ -match "^([0-9a-fA-F]{64})\s+\*?$escapedArchive$" } |
+        Select-Object -First 1
+    if (-not $checksumLine) {
+        Stop-Installer "checksums.txt does not contain an entry for $archive"
+    }
+
+    $expectedHash = ([Regex]::Match($checksumLine, "^([0-9a-fA-F]{64})")).Groups[1].Value
+    $actualHash = (Get-FileHash -Algorithm SHA256 -Path $archivePath).Hash
+    if ($actualHash -ne $expectedHash) {
+        Stop-Installer "checksum mismatch for $archive; the downloaded file was not installed"
+    }
+
+    $extractDir = Join-Path $workDir "extract"
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $extractDir
+    $sourceBinary = Join-Path $extractDir "$program.exe"
+    if (-not (Test-Path -LiteralPath $sourceBinary -PathType Leaf)) {
+        Stop-Installer "release archive did not contain $program.exe"
+    }
+
+    $target = Join-Path $InstallDir "$program.exe"
+    $staged = Join-Path $InstallDir ".$program.exe.new-$([Guid]::NewGuid().ToString('N'))"
+    Copy-Item -LiteralPath $sourceBinary -Destination $staged
+
+    try {
+        if (Test-Path -LiteralPath $target -PathType Leaf) {
+            $backup = Join-Path $InstallDir ".$program.exe.backup-$([Guid]::NewGuid().ToString('N'))"
+            [IO.File]::Replace($staged, $target, $backup, $true)
+            Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
+        }
+        else {
+            [IO.File]::Move($staged, $target)
+        }
+    }
+    catch {
+        Remove-Item -LiteralPath $staged -Force -ErrorAction SilentlyContinue
+        Stop-Installer "cannot install to '$target'; close any running copy and check permissions"
+    }
+
+    Write-Host "Installed $program to $target"
+    $normalizedInstallDir = $InstallDir.TrimEnd('\', '/')
+    $onPath = @($env:PATH -split [IO.Path]::PathSeparator |
+        Where-Object { $_ -and $_.TrimEnd('\', '/') -eq $normalizedInstallDir })
+    if ($onPath.Count -gt 0) {
+        Write-Host "Next: $program --help"
+    }
+    else {
+        Write-Host "Next: add '$InstallDir' to PATH, then run: $program --help"
+        Write-Host "Or run now: & `"$target`" --help"
+    }
+}
+finally {
+    Remove-Item -LiteralPath $workDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,178 @@
+#!/bin/sh
+
+set -eu
+
+REPOSITORY="doggy8088/holidaybook"
+PROGRAM="holidaybook"
+version="latest"
+install_dir="${HOLIDAYBOOK_INSTALL_DIR:-}"
+
+usage() {
+  cat <<'EOF'
+Install holidaybook from GitHub Releases.
+
+Usage:
+  install.sh [--version VERSION] [--dir DIRECTORY]
+
+Options:
+  -v, --version VERSION  Release tag to install (default: latest)
+  -d, --dir DIRECTORY    Installation directory (default: ~/.local/bin)
+  -h, --help             Show this help
+EOF
+}
+
+die() {
+  printf 'holidaybook installer: %s\n' "$*" >&2
+  exit 1
+}
+
+if [ -z "$install_dir" ] && [ -n "${HOME:-}" ]; then
+  install_dir="${HOME}/.local/bin"
+fi
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -v|--version)
+      [ "$#" -ge 2 ] || die "$1 requires a value"
+      version="$2"
+      shift 2
+      ;;
+    --version=*)
+      version=${1#*=}
+      shift
+      ;;
+    -d|--dir)
+      [ "$#" -ge 2 ] || die "$1 requires a value"
+      install_dir="$2"
+      shift 2
+      ;;
+    --dir=*)
+      install_dir=${1#*=}
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1 (try --help)"
+      ;;
+  esac
+done
+
+[ -n "$version" ] || die "version cannot be empty"
+[ -n "$install_dir" ] ||
+  die "installation directory cannot be empty; use --dir when HOME is not set"
+
+case "$(uname -s)" in
+  Darwin) os="darwin" ;;
+  Linux) os="linux" ;;
+  *) die "unsupported operating system: $(uname -s); use macOS or Linux" ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64) arch="amd64" ;;
+  arm64|aarch64) arch="arm64" ;;
+  *) die "unsupported architecture: $(uname -m); use amd64 or arm64" ;;
+esac
+
+archive="${PROGRAM}_${os}_${arch}.tar.gz"
+if [ "$version" = "latest" ]; then
+  release_url="https://github.com/${REPOSITORY}/releases/latest/download"
+else
+  case "$version" in
+    v*) tag="$version" ;;
+    *) tag="v$version" ;;
+  esac
+  release_url="https://github.com/${REPOSITORY}/releases/download/${tag}"
+fi
+
+mkdir -p "$install_dir" ||
+  die "cannot create $install_dir; choose a writable directory with --dir"
+work_dir="${install_dir}/.${PROGRAM}-install.$$"
+staged_binary=""
+umask 077
+mkdir "$work_dir" || die "cannot create temporary directory in $install_dir"
+
+cleanup() {
+  if [ -n "$staged_binary" ]; then
+    rm -f "$staged_binary"
+  fi
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+download() {
+  url="$1"
+  destination="$2"
+  case "$url" in
+    https://github.com/*) ;;
+    *) die "refusing non-GitHub or non-HTTPS download URL: $url" ;;
+  esac
+
+  if command -v curl >/dev/null 2>&1; then
+    curl --fail --location --silent --show-error \
+      --proto '=https' --tlsv1.2 --output "$destination" "$url" ||
+      die "download failed: $url"
+  elif command -v wget >/dev/null 2>&1; then
+    wget --quiet --https-only --output-document="$destination" "$url" ||
+      die "download failed: $url"
+  else
+    die "curl or wget is required to download the release"
+  fi
+}
+
+printf 'Downloading %s (%s/%s)...\n' "$PROGRAM" "$os" "$arch"
+download "${release_url}/${archive}" "${work_dir}/${archive}"
+download "${release_url}/checksums.txt" "${work_dir}/checksums.txt"
+
+expected_hash=$(
+  awk -v file="$archive" \
+    '$2 == file || $2 == "*" file { print tolower($1); exit }' \
+    "${work_dir}/checksums.txt"
+)
+[ -n "$expected_hash" ] ||
+  die "checksums.txt does not contain an entry for $archive"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_hash=$(sha256sum "${work_dir}/${archive}" | awk '{ print tolower($1) }')
+elif command -v shasum >/dev/null 2>&1; then
+  actual_hash=$(shasum -a 256 "${work_dir}/${archive}" | awk '{ print tolower($1) }')
+elif command -v openssl >/dev/null 2>&1; then
+  actual_hash=$(openssl dgst -sha256 "${work_dir}/${archive}" | awk '{ print tolower($NF) }')
+else
+  die "sha256sum, shasum, or openssl is required to verify $archive"
+fi
+
+if [ "$actual_hash" != "$expected_hash" ]; then
+  die "checksum mismatch for $archive; the downloaded file was not installed"
+fi
+
+command -v tar >/dev/null 2>&1 || die "tar is required to extract $archive"
+mkdir "${work_dir}/extract"
+tar -xzf "${work_dir}/${archive}" -C "${work_dir}/extract" ||
+  die "could not extract $archive"
+
+source_binary="${work_dir}/extract/${PROGRAM}"
+[ -f "$source_binary" ] ||
+  die "release archive did not contain the $PROGRAM binary"
+
+staged_binary="${install_dir}/.${PROGRAM}.new.$$"
+cp "$source_binary" "$staged_binary" ||
+  die "cannot stage the binary in $install_dir"
+chmod 755 "$staged_binary" ||
+  die "cannot make the staged binary executable"
+mv -f "$staged_binary" "${install_dir}/${PROGRAM}" ||
+  die "cannot install to ${install_dir}/${PROGRAM}; check permissions"
+staged_binary=""
+
+printf 'Installed %s to %s\n' "$PROGRAM" "${install_dir}/${PROGRAM}"
+case ":${PATH:-}:" in
+  *":${install_dir}:"*)
+    printf 'Next: %s --help\n' "$PROGRAM"
+    ;;
+  *)
+    printf 'Next: add %s to PATH, then run: %s --help\n' "$install_dir" "$PROGRAM"
+    ;;
+esac

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -92,6 +92,8 @@ func parseArgs(args []string) (options, string, error) {
 	flags.BoolVar(&opts.json, "json", false, "")
 	flags.BoolVar(&opts.version, "version", false, "")
 	flags.BoolVar(&opts.help, "help", false, "")
+	// Register -h explicitly; flag.ErrHelp would otherwise bypass the argument checks below.
+	flags.BoolVar(&opts.help, "h", false, "")
 
 	normalized, err := normalizeArgs(args)
 	if err != nil {
@@ -150,7 +152,7 @@ func writeUsage(w io.Writer) {
 	fmt.Fprintf(w, "  --base-url URL     覆寫資料來源，預設 %s\n", holiday.DefaultBaseURL)
 	fmt.Fprintf(w, "  --timeout DURATION 覆寫連線逾時，預設 %s\n", holiday.DefaultTimeout)
 	fmt.Fprintln(w, "  --version          顯示版本")
-	fmt.Fprintln(w, "  --help             顯示此說明")
+	fmt.Fprintln(w, "  --help, -h         顯示此說明")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "結束碼：0 成功、1 執行期錯誤、2 參數錯誤")
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,0 +1,208 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/doggy8088/holidaybook/internal/holiday"
+)
+
+const (
+	ExitOK      = 0
+	ExitRuntime = 1
+	ExitUsage   = 2
+)
+
+type options struct {
+	baseURL string
+	timeout time.Duration
+	json    bool
+	version bool
+	help    bool
+}
+
+type errorOutput struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+func Run(ctx context.Context, args []string, stdout, stderr io.Writer, version string) int {
+	opts, date, err := parseArgs(args)
+	if err != nil {
+		writeError(stderr, opts.json, "usage", err.Error())
+		return ExitUsage
+	}
+	if opts.help {
+		writeUsage(stdout)
+		return ExitOK
+	}
+	if opts.version {
+		fmt.Fprintf(stdout, "holidaybook %s\n", version)
+		return ExitOK
+	}
+	if err := holiday.ValidateDate(date); err != nil {
+		writeError(stderr, opts.json, "invalid_date", "日期格式錯誤：請使用有效的 YYYY-MM-DD 日期")
+		return ExitUsage
+	}
+
+	client, err := holiday.NewClient(opts.baseURL, opts.timeout)
+	if err != nil {
+		writeError(stderr, opts.json, "invalid_configuration", "設定錯誤："+err.Error())
+		return ExitUsage
+	}
+	day, err := client.FetchDay(ctx, date)
+	if err != nil {
+		code, message := fetchError(err)
+		writeError(stderr, opts.json, code, message)
+		return ExitRuntime
+	}
+
+	if opts.json {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		if err := encoder.Encode(day); err != nil {
+			writeError(stderr, true, "output_error", "無法輸出查詢結果")
+			return ExitRuntime
+		}
+		return ExitOK
+	}
+
+	writeHuman(stdout, day)
+	return ExitOK
+}
+
+func parseArgs(args []string) (options, string, error) {
+	opts := options{
+		baseURL: holiday.DefaultBaseURL,
+		timeout: holiday.DefaultTimeout,
+	}
+	flags := flag.NewFlagSet("holidaybook", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.StringVar(&opts.baseURL, "base-url", opts.baseURL, "")
+	flags.DurationVar(&opts.timeout, "timeout", opts.timeout, "")
+	flags.BoolVar(&opts.json, "json", false, "")
+	flags.BoolVar(&opts.version, "version", false, "")
+	flags.BoolVar(&opts.help, "help", false, "")
+
+	normalized, err := normalizeArgs(args)
+	if err != nil {
+		return opts, "", err
+	}
+	if err := flags.Parse(normalized); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			opts.help = true
+			return opts, "", nil
+		}
+		return opts, "", errors.New("無效的命令列參數（請用 --help 查看用法）")
+	}
+	if opts.help || opts.version {
+		if flags.NArg() != 0 {
+			return opts, "", errors.New("--help 與 --version 不接受日期參數")
+		}
+		return opts, "", nil
+	}
+	if flags.NArg() != 1 {
+		return opts, "", errors.New("請提供一個 YYYY-MM-DD 日期")
+	}
+	return opts, flags.Arg(0), nil
+}
+
+// normalizeArgs lets users place flags before or after the positional date.
+func normalizeArgs(args []string) ([]string, error) {
+	var flags, positional []string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--json" || arg == "--version" || arg == "--help":
+			flags = append(flags, arg)
+		case arg == "--base-url" || arg == "--timeout":
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("%s 需要一個值", arg)
+			}
+			flags = append(flags, arg, args[i+1])
+			i++
+		case strings.HasPrefix(arg, "--base-url=") || strings.HasPrefix(arg, "--timeout="):
+			flags = append(flags, arg)
+		case strings.HasPrefix(arg, "-"):
+			flags = append(flags, arg)
+		default:
+			positional = append(positional, arg)
+		}
+	}
+	return append(flags, positional...), nil
+}
+
+func writeUsage(w io.Writer) {
+	fmt.Fprintln(w, "用法：holidaybook [--json] [--base-url URL] [--timeout 10s] YYYY-MM-DD")
+	fmt.Fprintln(w, "      holidaybook --version")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "選項：")
+	fmt.Fprintln(w, "  --json             輸出機器可讀 JSON（成功與錯誤皆為 JSON）")
+	fmt.Fprintf(w, "  --base-url URL     覆寫資料來源，預設 %s\n", holiday.DefaultBaseURL)
+	fmt.Fprintf(w, "  --timeout DURATION 覆寫連線逾時，預設 %s\n", holiday.DefaultTimeout)
+	fmt.Fprintln(w, "  --version          顯示版本")
+	fmt.Fprintln(w, "  --help             顯示此說明")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "結束碼：0 成功、1 執行期錯誤、2 參數錯誤")
+}
+
+func writeHuman(w io.Writer, day holiday.Day) {
+	label := "上班日"
+	if day.IsHoliday {
+		label = "放假"
+	}
+	if day.Name != "" {
+		label += "（" + day.Name + "）"
+	}
+	fmt.Fprintf(w, "%s：%s\n", day.Date, label)
+	if day.Category != "" {
+		fmt.Fprintf(w, "類別：%s\n", day.Category)
+	}
+	if day.Description != "" {
+		fmt.Fprintf(w, "說明：%s\n", day.Description)
+	}
+}
+
+func writeError(w io.Writer, machine bool, code, message string) {
+	if !machine {
+		fmt.Fprintln(w, "錯誤："+message)
+		return
+	}
+
+	var output errorOutput
+	output.Error.Code = code
+	output.Error.Message = message
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	_ = encoder.Encode(output)
+}
+
+func fetchError(err error) (string, string) {
+	var statusErr *holiday.HTTPStatusError
+	var responseErr *holiday.ResponseError
+	switch {
+	case errors.As(err, &statusErr):
+		return "http_error", "假日服務回傳 HTTP " + strconv.Itoa(statusErr.StatusCode)
+	case errors.As(err, &responseErr):
+		return "invalid_response", "假日服務回傳無效資料"
+	case errors.Is(err, context.Canceled):
+		return "canceled", "查詢已取消"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout", "連線假日服務逾時"
+	default:
+		var timeout interface{ Timeout() bool }
+		if errors.As(err, &timeout) && timeout.Timeout() {
+			return "timeout", "連線假日服務逾時"
+		}
+		return "network_error", "無法連線假日服務"
+	}
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1,0 +1,227 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunHumanHolidayAndWorkday(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "holiday",
+			body: `{"date":"20261010","name":"國慶日","isHoliday":1,"holidaycategory":"國定假日","description":"放假一日。"}`,
+			want: "2026-10-10：放假（國慶日）\n類別：國定假日\n說明：放假一日。\n",
+		},
+		{
+			name: "workday",
+			body: `{"date":"20261010","name":"","isHoliday":0,"holidaycategory":"","description":""}`,
+			want: "2026-10-10：上班日\n",
+		},
+		{
+			name: "workday with details",
+			body: `{"date":"20261010","name":"軍人節","isHoliday":0,"holidaycategory":"特定節日","description":"軍人依國防部規定辦理。"}`,
+			want: "2026-10-10：上班日（軍人節）\n類別：特定節日\n說明：軍人依國防部規定辦理。\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newJSONServer(t, http.StatusOK, tt.body)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			exitCode := Run(context.Background(), []string{"2026-10-10", "--base-url", server.URL}, &stdout, &stderr, "test")
+			if exitCode != ExitOK {
+				t.Fatalf("exit code = %d, stderr = %s", exitCode, stderr.String())
+			}
+			if stdout.String() != tt.want {
+				t.Fatalf("stdout = %q, want %q", stdout.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestRunMachineOutput(t *testing.T) {
+	server := newJSONServer(t, http.StatusOK, `{"date":"20261010","name":"國慶日","isHoliday":1,"holidaycategory":"國定假日","description":"放假一日。"}`)
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run(context.Background(), []string{"--json", "--base-url", server.URL, "2026-10-10"}, &stdout, &stderr, "test")
+	if exitCode != ExitOK {
+		t.Fatalf("exit code = %d, stderr = %s", exitCode, stderr.String())
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+	for _, key := range []string{"date", "isHoliday", "name", "category", "description"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("JSON output missing %q: %s", key, stdout.String())
+		}
+	}
+	if got["date"] != "2026-10-10" || got["isHoliday"] != true {
+		t.Fatalf("JSON output = %s", stdout.String())
+	}
+}
+
+func TestRunInvalidDate(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := Run(context.Background(), []string{"--json", "2026-02-30"}, &stdout, &stderr, "test")
+	if exitCode != ExitUsage {
+		t.Fatalf("exit code = %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), `"code":"invalid_date"`) {
+		t.Fatalf("stderr = %s", stderr.String())
+	}
+}
+
+func TestRunHTTPAndMalformedErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+		body string
+		want string
+	}{
+		{name: "HTTP error", code: http.StatusNotFound, body: `not found`, want: "HTTP 404"},
+		{name: "malformed", code: http.StatusOK, body: `{`, want: "無效資料"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newJSONServer(t, tt.code, tt.body)
+			defer server.Close()
+
+			var stdout, stderr bytes.Buffer
+			exitCode := Run(context.Background(), []string{"--base-url", server.URL, "2026-10-10"}, &stdout, &stderr, "test")
+			if exitCode != ExitRuntime {
+				t.Fatalf("exit code = %d", exitCode)
+			}
+			if !strings.Contains(stderr.String(), tt.want) {
+				t.Fatalf("stderr = %s", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunVersion(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := Run(context.Background(), []string{"--version"}, &stdout, &stderr, "1.2.3")
+	if exitCode != ExitOK || stdout.String() != "holidaybook 1.2.3\n" || stderr.Len() != 0 {
+		t.Fatalf("exit=%d stdout=%q stderr=%q", exitCode, stdout.String(), stderr.String())
+	}
+}
+
+func TestRunHelpFlags(t *testing.T) {
+	for _, args := range [][]string{{"--help"}, {"-h"}, {"-help"}} {
+		var stdout, stderr bytes.Buffer
+		exitCode := Run(context.Background(), args, &stdout, &stderr, "test")
+		if exitCode != ExitOK {
+			t.Fatalf("Run(%v) exit = %d, stderr = %s", args, exitCode, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "用法：holidaybook") || stderr.Len() != 0 {
+			t.Fatalf("Run(%v) stdout = %q stderr = %q", args, stdout.String(), stderr.String())
+		}
+	}
+}
+
+func TestRunUsageErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "missing date", args: []string{"--json"}, want: `"code":"usage"`},
+		{name: "two dates", args: []string{"--json", "2026-10-10", "2026-10-11"}, want: `"code":"usage"`},
+		{name: "unknown flag", args: []string{"--json", "--nope"}, want: `"code":"usage"`},
+		{name: "help with date", args: []string{"--json", "--help", "2026-10-10"}, want: `"code":"usage"`},
+		{name: "bad base url", args: []string{"--json", "--base-url", "ftp://example.com", "2026-10-10"}, want: `"code":"invalid_configuration"`},
+		{name: "bad timeout", args: []string{"--json", "--timeout", "0s", "2026-10-10"}, want: `"code":"invalid_configuration"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			exitCode := Run(context.Background(), tt.args, &stdout, &stderr, "test")
+			if exitCode != ExitUsage {
+				t.Fatalf("exit code = %d, stderr = %s", exitCode, stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tt.want) {
+				t.Fatalf("stderr = %s", stderr.String())
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout = %q, want empty", stdout.String())
+			}
+		})
+	}
+}
+
+func TestRunFlagsAfterDate(t *testing.T) {
+	server := newJSONServer(t, http.StatusOK, `{"date":"20261010","name":"","isHoliday":0,"holidaycategory":"","description":""}`)
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run(context.Background(), []string{"2026-10-10", "--json", "--base-url=" + server.URL, "--timeout=5s"}, &stdout, &stderr, "test")
+	if exitCode != ExitOK {
+		t.Fatalf("exit code = %d, stderr = %s", exitCode, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"isHoliday":false`) {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestRunCanceledContext(t *testing.T) {
+	server := newJSONServer(t, http.StatusOK, `{"date":"20261010","isHoliday":1}`)
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run(ctx, []string{"--json", "--base-url", server.URL, "2026-10-10"}, &stdout, &stderr, "test")
+	if exitCode != ExitRuntime {
+		t.Fatalf("exit code = %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), `"code":"canceled"`) {
+		t.Fatalf("stderr = %s", stderr.String())
+	}
+}
+
+func TestRunTimeoutError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"date":"20261010","isHoliday":1}`))
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	exitCode := Run(context.Background(), []string{"--json", "--base-url", server.URL, "--timeout", "20ms", "2026-10-10"}, &stdout, &stderr, "test")
+	if exitCode != ExitRuntime {
+		t.Fatalf("exit code = %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), `"code":"timeout"`) {
+		t.Fatalf("stderr = %s", stderr.String())
+	}
+}
+
+func newJSONServer(t *testing.T, statusCode int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/2026-10-10.json" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write([]byte(body))
+	}))
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -123,7 +123,7 @@ func TestRunVersion(t *testing.T) {
 }
 
 func TestRunHelpFlags(t *testing.T) {
-	for _, args := range [][]string{{"--help"}, {"-h"}, {"-help"}} {
+	for _, args := range [][]string{{"--help"}, {"-h"}, {"-help"}, {"--h"}} {
 		var stdout, stderr bytes.Buffer
 		exitCode := Run(context.Background(), args, &stdout, &stderr, "test")
 		if exitCode != ExitOK {
@@ -131,6 +131,9 @@ func TestRunHelpFlags(t *testing.T) {
 		}
 		if !strings.Contains(stdout.String(), "用法：holidaybook") || stderr.Len() != 0 {
 			t.Fatalf("Run(%v) stdout = %q stderr = %q", args, stdout.String(), stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "-h") {
+			t.Fatalf("Run(%v) usage output does not document -h: %q", args, stdout.String())
 		}
 	}
 }
@@ -145,6 +148,8 @@ func TestRunUsageErrors(t *testing.T) {
 		{name: "two dates", args: []string{"--json", "2026-10-10", "2026-10-11"}, want: `"code":"usage"`},
 		{name: "unknown flag", args: []string{"--json", "--nope"}, want: `"code":"usage"`},
 		{name: "help with date", args: []string{"--json", "--help", "2026-10-10"}, want: `"code":"usage"`},
+		{name: "short help with date", args: []string{"--json", "-h", "2026-10-10"}, want: `"code":"usage"`},
+		{name: "short help with date reversed", args: []string{"--json", "2026-10-10", "-h"}, want: `"code":"usage"`},
 		{name: "bad base url", args: []string{"--json", "--base-url", "ftp://example.com", "2026-10-10"}, want: `"code":"invalid_configuration"`},
 		{name: "bad timeout", args: []string{"--json", "--timeout", "0s", "2026-10-10"}, want: `"code":"invalid_configuration"`},
 	}

--- a/internal/holiday/client.go
+++ b/internal/holiday/client.go
@@ -1,0 +1,145 @@
+package holiday
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultBaseURL = "https://holiday.gh.miniasp.com"
+	DefaultTimeout = 10 * time.Second
+	maxBodySize    = 1 << 20
+)
+
+type Day struct {
+	Date        string `json:"date"`
+	IsHoliday   bool   `json:"isHoliday"`
+	Name        string `json:"name"`
+	Category    string `json:"category"`
+	Description string `json:"description"`
+}
+
+type HTTPStatusError struct {
+	StatusCode int
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("holiday API returned HTTP %d", e.StatusCode)
+}
+
+type ResponseError struct {
+	err error
+}
+
+func (e *ResponseError) Error() string {
+	return "invalid holiday API response: " + e.err.Error()
+}
+
+func (e *ResponseError) Unwrap() error {
+	return e.err
+}
+
+type Client struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+}
+
+func NewClient(baseURL string, timeout time.Duration) (*Client, error) {
+	if timeout <= 0 {
+		return nil, errors.New("timeout must be greater than zero")
+	}
+
+	parsed, err := url.Parse(strings.TrimRight(baseURL, "/"))
+	if err != nil {
+		return nil, fmt.Errorf("parse base URL: %w", err)
+	}
+	if (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return nil, errors.New("base URL must be an absolute HTTP or HTTPS URL")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, errors.New("base URL must not contain a query or fragment")
+	}
+
+	return &Client{
+		baseURL:    parsed,
+		httpClient: &http.Client{Timeout: timeout},
+	}, nil
+}
+
+func (c *Client) FetchDay(ctx context.Context, isoDate string) (Day, error) {
+	if err := ValidateDate(isoDate); err != nil {
+		return Day{}, err
+	}
+
+	endpoint := *c.baseURL
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + "/" + isoDate + ".json"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return Day{}, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "holidaybook")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return Day{}, fmt.Errorf("request holiday API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxBodySize))
+		return Day{}, &HTTPStatusError{StatusCode: resp.StatusCode}
+	}
+
+	var payload struct {
+		Date        string `json:"date"`
+		IsHoliday   *int   `json:"isHoliday"`
+		Name        string `json:"name"`
+		Category    string `json:"holidaycategory"`
+		Description string `json:"description"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, maxBodySize))
+	if err := decoder.Decode(&payload); err != nil {
+		return Day{}, &ResponseError{err: err}
+	}
+	if err := ensureJSONEnd(decoder); err != nil {
+		return Day{}, &ResponseError{err: err}
+	}
+	if payload.Date == "" || payload.IsHoliday == nil {
+		return Day{}, &ResponseError{err: errors.New("missing required fields")}
+	}
+	if payload.Date != strings.ReplaceAll(isoDate, "-", "") {
+		return Day{}, &ResponseError{err: errors.New("date does not match request")}
+	}
+	if *payload.IsHoliday != 0 && *payload.IsHoliday != 1 {
+		return Day{}, &ResponseError{err: errors.New("invalid holiday status")}
+	}
+
+	return Day{
+		Date:        isoDate,
+		IsHoliday:   *payload.IsHoliday == 1,
+		Name:        strings.TrimSpace(payload.Name),
+		Category:    strings.TrimSpace(payload.Category),
+		Description: strings.TrimSpace(payload.Description),
+	}, nil
+}
+
+func ensureJSONEnd(decoder *json.Decoder) error {
+	var extra json.RawMessage
+	err := decoder.Decode(&extra)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return errors.New("response contains multiple JSON values")
+	}
+	return err
+}

--- a/internal/holiday/client_test.go
+++ b/internal/holiday/client_test.go
@@ -1,0 +1,153 @@
+package holiday
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestFetchDay(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantHoliday bool
+		wantName    string
+	}{
+		{
+			name:        "holiday",
+			body:        `{"_id":1652,"date":"20261010","name":"國慶日","isHoliday":1,"holidaycategory":"放假之紀念日及節日","description":"全國各機關學校放假一日。"}`,
+			wantHoliday: true,
+			wantName:    "國慶日",
+		},
+		{
+			name:        "workday",
+			body:        `{"_id":0,"date":"20261010","name":"","isHoliday":0,"holidaycategory":"","description":""}`,
+			wantHoliday: false,
+			wantName:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/2026-10-10.json" {
+					t.Errorf("path = %q", r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client, err := NewClient(server.URL, time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := client.FetchDay(context.Background(), "2026-10-10")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Date != "2026-10-10" || got.IsHoliday != tt.wantHoliday || got.Name != tt.wantName {
+				t.Fatalf("FetchDay() = %+v", got)
+			}
+		})
+	}
+}
+
+func TestFetchDayErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{name: "HTTP error", statusCode: http.StatusServiceUnavailable, body: `unavailable`},
+		{name: "malformed JSON", statusCode: http.StatusOK, body: `{"date":`},
+		{name: "empty response", statusCode: http.StatusOK, body: ``},
+		{name: "missing fields", statusCode: http.StatusOK, body: `{}`},
+		{name: "wrong date", statusCode: http.StatusOK, body: `{"date":"20261011","isHoliday":1}`},
+		{name: "invalid status", statusCode: http.StatusOK, body: `{"date":"20261010","isHoliday":2}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client, err := NewClient(server.URL, time.Second)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = client.FetchDay(context.Background(), "2026-10-10")
+			if err == nil {
+				t.Fatal("FetchDay() error = nil")
+			}
+			if tt.statusCode != http.StatusOK {
+				var statusErr *HTTPStatusError
+				if !errors.As(err, &statusErr) || statusErr.StatusCode != tt.statusCode {
+					t.Fatalf("FetchDay() error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestFetchDayTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"date":"20261010","isHoliday":1}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, 10*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.FetchDay(context.Background(), "2026-10-10")
+	if err == nil {
+		t.Fatal("FetchDay() error = nil")
+	}
+}
+
+func TestFetchDayRejectsInvalidDate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request for %q", r.URL.Path)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, date := range []string{"2026-13-01", "../secret", "2026-10-10?x=1"} {
+		if _, err := client.FetchDay(context.Background(), date); err == nil {
+			t.Errorf("FetchDay(%q) error = nil", date)
+		}
+	}
+}
+
+func TestNewClientRejectsInvalidBaseURL(t *testing.T) {
+	for _, baseURL := range []string{"", "example.com", "ftp://example.com", "https://example.com?a=b", "https://example.com#frag"} {
+		if _, err := NewClient(baseURL, time.Second); err == nil {
+			t.Errorf("NewClient(%q) error = nil", baseURL)
+		}
+	}
+	if _, err := NewClient("https://example.com/", 0); err == nil {
+		t.Error("NewClient() with zero timeout error = nil")
+	}
+}
+
+func TestValidateDate(t *testing.T) {
+	if err := ValidateDate("2024-02-29"); err != nil {
+		t.Fatalf("valid date rejected: %v", err)
+	}
+	for _, date := range []string{"2026-2-01", "2026-02-30", "not-a-date"} {
+		if err := ValidateDate(date); err == nil {
+			t.Errorf("ValidateDate(%q) error = nil", date)
+		}
+	}
+}

--- a/internal/holiday/date.go
+++ b/internal/holiday/date.go
@@ -1,0 +1,21 @@
+package holiday
+
+import (
+	"errors"
+	"regexp"
+	"time"
+)
+
+var isoDatePattern = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
+func ValidateDate(value string) error {
+	if !isoDatePattern.MatchString(value) {
+		return errors.New("date must use YYYY-MM-DD format")
+	}
+
+	parsed, err := time.Parse("2006-01-02", value)
+	if err != nil || parsed.Format("2006-01-02") != value {
+		return errors.New("date is not a valid calendar date")
+	}
+	return nil
+}

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+holiday.gh.miniasp.com

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,318 @@
+/*
+ * Taiwan Holiday Lookup client-side query tool.
+ * Vanilla JS, no build step, no third-party dependencies.
+ * Renders API-provided text with textContent only (never innerHTML).
+ */
+(function () {
+  "use strict";
+
+  var DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+  var form = document.getElementById("query-form");
+  var dateInput = document.getElementById("date-input");
+  var prevBtn = document.getElementById("prev-day");
+  var nextBtn = document.getElementById("next-day");
+  var todayBtn = document.getElementById("today-btn");
+  var quickButtons = document.querySelectorAll(".quick-dates [data-offset]");
+
+  var result = document.getElementById("result");
+  var errorMessage = document.getElementById("error-message");
+  var emptyMessage = document.getElementById("empty-message");
+  var resultDate = document.getElementById("result-date");
+  var resultBadge = document.getElementById("result-badge");
+  var resultName = document.getElementById("result-name");
+  var resultCategory = document.getElementById("result-category");
+  var resultDescription = document.getElementById("result-description");
+  var resultRaw = document.getElementById("result-raw");
+
+  var activeController = null;
+
+  /** Returns today's date as YYYY-MM-DD in Asia/Taipei local time. */
+  function getTaipeiToday() {
+    try {
+      var parts = new Intl.DateTimeFormat("en-CA", {
+        timeZone: "Asia/Taipei",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit"
+      }).formatToParts(new Date());
+      var map = {};
+      for (var i = 0; i < parts.length; i++) {
+        map[parts[i].type] = parts[i].value;
+      }
+      if (map.year && map.month && map.day) {
+        return map.year + "-" + map.month + "-" + map.day;
+      }
+    } catch (err) {
+      /* fall through to manual UTC+8 calculation below */
+    }
+    var now = new Date();
+    var taipeiMs = now.getTime() + (now.getTimezoneOffset() + 8 * 60) * 60000;
+    var taipei = new Date(taipeiMs);
+    return toDateStr(taipei);
+  }
+
+  function pad2(n) {
+    return n < 10 ? "0" + n : String(n);
+  }
+
+  function toDateStr(d) {
+    return d.getFullYear() + "-" + pad2(d.getMonth() + 1) + "-" + pad2(d.getDate());
+  }
+
+  /** Validates a YYYY-MM-DD string, rejecting impossible dates like 2025-02-30. */
+  function isValidDateStr(str) {
+    if (!DATE_RE.test(str)) return false;
+    var segments = str.split("-");
+    var y = parseInt(segments[0], 10);
+    var m = parseInt(segments[1], 10);
+    var d = parseInt(segments[2], 10);
+    var date = new Date(Date.UTC(y, m - 1, d));
+    return (
+      date.getUTCFullYear() === y &&
+      date.getUTCMonth() === m - 1 &&
+      date.getUTCDate() === d
+    );
+  }
+
+  function addDays(str, delta) {
+    var segments = str.split("-");
+    var date = new Date(Date.UTC(
+      parseInt(segments[0], 10),
+      parseInt(segments[1], 10) - 1,
+      parseInt(segments[2], 10)
+    ));
+    date.setUTCDate(date.getUTCDate() + delta);
+    return (
+      date.getUTCFullYear() +
+      "-" +
+      pad2(date.getUTCMonth() + 1) +
+      "-" +
+      pad2(date.getUTCDate())
+    );
+  }
+
+  function formatWeekday(str) {
+    var segments = str.split("-");
+    var date = new Date(Date.UTC(
+      parseInt(segments[0], 10),
+      parseInt(segments[1], 10) - 1,
+      parseInt(segments[2], 10)
+    ));
+    try {
+      return new Intl.DateTimeFormat("zh-Hant-TW", {
+        weekday: "long",
+        timeZone: "UTC"
+      }).format(date);
+    } catch (err) {
+      return "";
+    }
+  }
+
+  function setState(state) {
+    result.setAttribute("data-state", state);
+  }
+
+  /** Returns a trimmed string only for genuine string fields, otherwise "". */
+  function text(value) {
+    return typeof value === "string" ? value.trim() : "";
+  }
+
+  /** Accepts the documented 0/1 (or boolean/string) holiday flag, else null. */
+  function readHolidayFlag(value) {
+    if (value === 1 || value === "1" || value === true) return true;
+    if (value === 0 || value === "0" || value === false) return false;
+    return null;
+  }
+
+  /** The static API reports dates as YYYYMMDD; accept YYYY-MM-DD defensively. */
+  function matchesRequestedDate(value, dateStr) {
+    var normalized = text(value).replace(/-/g, "");
+    return normalized === dateStr.replace(/-/g, "");
+  }
+
+  function setQueryParam(dateStr) {
+    try {
+      var url = new URL(window.location.href);
+      url.searchParams.set("date", dateStr);
+      window.history.replaceState(null, "", url.toString());
+    } catch (err) {
+      /* URL API unsupported: skip deep-linking, query still works */
+    }
+  }
+
+  function getInitialDate() {
+    try {
+      var params = new URLSearchParams(window.location.search);
+      var fromQuery = params.get("date");
+      if (fromQuery && isValidDateStr(fromQuery)) {
+        return fromQuery;
+      }
+    } catch (err) {
+      /* URLSearchParams unsupported: ignore and fall back to today */
+    }
+    return getTaipeiToday();
+  }
+
+  function renderSuccess(dateStr, data) {
+    var weekday = formatWeekday(dateStr);
+    resultDate.textContent = weekday ? dateStr + "（" + weekday + "）" : dateStr;
+
+    var isHoliday = readHolidayFlag(data.isHoliday) === true;
+    resultBadge.textContent = isHoliday ? "放假" : "上班";
+    resultBadge.className = "badge " + (isHoliday ? "badge--holiday" : "badge--workday");
+
+    resultName.textContent = text(data.name) || "（無特定假日名稱）";
+    resultCategory.textContent = text(data.holidaycategory) || "（無）";
+    resultDescription.textContent = text(data.description) || "（無）";
+
+    resultRaw.textContent = JSON.stringify(data, null, 2);
+
+    setState("success");
+  }
+
+  function renderEmpty(dateStr) {
+    emptyMessage.textContent =
+      "查無 " + dateStr + " 的資料，可能超出目前的資料涵蓋範圍（資料每日自動延伸，通常涵蓋近幾年）。";
+    setState("empty");
+  }
+
+  function renderError(message) {
+    errorMessage.textContent = message;
+    setState("error");
+  }
+
+  function queryDate(dateStr) {
+    if (!isValidDateStr(dateStr)) {
+      renderError("日期格式不正確，請使用 YYYY-MM-DD 格式，例如 2025-07-20。");
+      return;
+    }
+
+    setQueryParam(dateStr);
+    setState("loading");
+
+    if (activeController) {
+      activeController.abort();
+    }
+    var controller = typeof AbortController !== "undefined" ? new AbortController() : null;
+    activeController = controller;
+
+    fetch(dateStr + ".json", {
+      cache: "no-store",
+      signal: controller ? controller.signal : undefined
+    })
+      .then(function (response) {
+        if (response.status === 404) {
+          renderEmpty(dateStr);
+          return null;
+        }
+        if (!response.ok) {
+          throw new Error("HTTP " + response.status);
+        }
+        return response.json();
+      })
+      .then(function (data) {
+        if (data === null) return;
+        if (!data || typeof data !== "object" || Array.isArray(data)) {
+          renderError("回應格式不正確（預期單日 JSON 物件），請稍後再試一次。");
+          return;
+        }
+        if (!matchesRequestedDate(data.date, dateStr)) {
+          renderError("回應的日期與查詢的日期不符，請重新查詢一次。");
+          return;
+        }
+        if (readHolidayFlag(data.isHoliday) === null) {
+          renderError("回應缺少可辨識的 isHoliday 欄位，無法判斷放假狀態。");
+          return;
+        }
+        renderSuccess(dateStr, data);
+      })
+      .catch(function (err) {
+        if (err && err.name === "AbortError") return;
+        renderError("無法連線取得資料，請確認網路連線後再試一次（" + (err && err.message ? err.message : "未知錯誤") + "）。");
+      });
+  }
+
+  function currentInputDate() {
+    var value = dateInput.value;
+    return isValidDateStr(value) ? value : getTaipeiToday();
+  }
+
+  form.addEventListener("submit", function (event) {
+    event.preventDefault();
+    queryDate(currentInputDate());
+  });
+
+  prevBtn.addEventListener("click", function () {
+    var next = addDays(currentInputDate(), -1);
+    dateInput.value = next;
+    queryDate(next);
+  });
+
+  nextBtn.addEventListener("click", function () {
+    var next = addDays(currentInputDate(), 1);
+    dateInput.value = next;
+    queryDate(next);
+  });
+
+  todayBtn.addEventListener("click", function () {
+    var today = getTaipeiToday();
+    dateInput.value = today;
+    queryDate(today);
+  });
+
+  quickButtons.forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var offset = parseInt(btn.getAttribute("data-offset"), 10) || 0;
+      var target = addDays(getTaipeiToday(), offset);
+      dateInput.value = target;
+      queryDate(target);
+    });
+  });
+
+  /* ---- Copy-to-clipboard for code samples and raw JSON ---- */
+  document.querySelectorAll("[data-copy-target]").forEach(function (button) {
+    button.addEventListener("click", function () {
+      var targetId = button.getAttribute("data-copy-target");
+      var target = document.getElementById(targetId);
+      if (!target) return;
+      var text = target.textContent || "";
+
+      var done = function (ok) {
+        var original = button.textContent;
+        button.textContent = ok ? "已複製" : "複製失敗";
+        window.setTimeout(function () {
+          button.textContent = original;
+        }, 1500);
+      };
+
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(
+          function () { done(true); },
+          function () { done(false); }
+        );
+        return;
+      }
+
+      try {
+        var textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "absolute";
+        textarea.style.left = "-9999px";
+        document.body.appendChild(textarea);
+        textarea.select();
+        var ok = document.execCommand("copy");
+        document.body.removeChild(textarea);
+        done(ok);
+      } catch (err) {
+        done(false);
+      }
+    });
+  });
+
+  /* ---- Boot ---- */
+  var initialDate = getInitialDate();
+  dateInput.value = initialDate;
+  queryDate(initialDate);
+})();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>台灣假期速查｜給人與代理人的假日狀態 API</title>
+<meta name="description" content="輸入日期即可查詢台灣是否放假，並提供對應的靜態 JSON API、CLI 與 curl 範例，方便開發者與 AI 代理人整合。資料每日自動更新，免安裝、免金鑰。">
+<link rel="canonical" href="https://holiday.gh.miniasp.com/">
+<meta name="theme-color" content="#0d7a68" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#0c1210" media="(prefers-color-scheme: dark)">
+<meta name="color-scheme" content="light dark">
+
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="台灣假期速查">
+<meta property="og:title" content="台灣假期速查｜給人與代理人的假日狀態 API">
+<meta property="og:description" content="輸入日期即可查詢台灣是否放假，並提供對應的靜態 JSON API、CLI 與 curl 範例，方便開發者與 AI 代理人整合。">
+<meta property="og:url" content="https://holiday.gh.miniasp.com/">
+<meta property="og:locale" content="zh_TW">
+
+<link rel="icon" href="data:,">
+<link rel="stylesheet" href="styles.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "台灣假期資料",
+  "description": "台灣行政機關辦公日曆表衍生的每日、每月、每年假期狀態 JSON 資料集。",
+  "url": "https://holiday.gh.miniasp.com/",
+  "license": "https://data.taipei/",
+  "creator": {
+    "@type": "Organization",
+    "name": "臺北市政府"
+  },
+  "distribution": {
+    "@type": "DataDownload",
+    "encodingFormat": "application/json",
+    "contentUrl": "https://holiday.gh.miniasp.com/{YYYY-MM-DD}.json"
+  }
+}
+</script>
+</head>
+<body>
+<a class="skip-link" href="#main">跳到主要內容</a>
+
+<header class="site-header">
+  <div class="container site-header__inner">
+    <a class="brand" href="#main">
+      <span class="brand__mark">台灣假期速查</span>
+      <span class="brand__tagline">Taiwan Holiday Lookup</span>
+    </a>
+    <nav class="site-nav" aria-label="主要導覽">
+      <ul>
+        <li><a href="#lookup">查詢</a></li>
+        <li><a href="#cli">CLI／curl</a></li>
+        <li><a href="#api">API 說明</a></li>
+        <li><a href="https://github.com/doggy8088/holidaybook">GitHub</a></li>
+      </ul>
+    </nav>
+  </div>
+</header>
+
+<main id="main">
+
+  <section class="hero container" id="lookup" aria-labelledby="lookup-heading">
+    <div class="hero__intro">
+      <p class="hero__eyebrow">每日更新的靜態 JSON API</p>
+      <h1 id="lookup-heading">今天，放假嗎？</h1>
+      <p class="hero__lede">輸入任一日期，立即查出台灣的放假狀態、假期名稱與說明。同一份資料也能直接被程式、CLI 或 AI 代理人查詢。</p>
+    </div>
+
+    <noscript>
+      <p class="notice notice--empty">此查詢工具需要啟用 JavaScript 才能運作。你仍可直接開啟對應的 JSON 網址查詢，例如
+        <code>https://holiday.gh.miniasp.com/2025-07-20.json</code>。</p>
+    </noscript>
+
+    <form class="query-card query-form" id="query-form">
+      <div class="query-form__field">
+        <label for="date-input">查詢日期</label>
+        <div class="date-step">
+          <button type="button" class="icon-btn" id="prev-day" aria-label="查詢前一天">‹</button>
+          <input
+            type="date"
+            id="date-input"
+            name="date"
+            required
+            pattern="\d{4}-\d{2}-\d{2}"
+            autocomplete="off"
+          >
+          <button type="button" class="icon-btn" id="next-day" aria-label="查詢後一天">›</button>
+        </div>
+      </div>
+      <div class="query-form__actions">
+        <button type="submit" class="btn">查詢</button>
+        <button type="button" class="btn btn--ghost" id="today-btn">回到今天</button>
+      </div>
+    </form>
+
+    <div class="quick-dates" aria-label="快速查詢">
+      <button type="button" class="btn btn--ghost btn--small" data-offset="0">今天</button>
+      <button type="button" class="btn btn--ghost btn--small" data-offset="1">明天</button>
+      <button type="button" class="btn btn--ghost btn--small" data-offset="7">下週同一天</button>
+    </div>
+
+    <div class="result" id="result" data-state="idle" role="status" aria-live="polite">
+      <p class="result__state result__state--idle">選好日期後按下「查詢」，結果會顯示在這裡。</p>
+
+      <p class="result__state result__state--loading"><span class="spinner" aria-hidden="true"></span>查詢中…</p>
+
+      <div class="result__state result__state--error">
+        <p class="notice notice--error" id="error-message"></p>
+      </div>
+
+      <div class="result__state result__state--empty">
+        <p class="notice notice--empty" id="empty-message"></p>
+      </div>
+
+      <div class="result__state result__state--success">
+        <div class="status-row">
+          <span class="status-date" id="result-date"></span>
+          <span class="badge" id="result-badge"></span>
+        </div>
+        <dl class="result-detail">
+          <dt>假期名稱</dt>
+          <dd id="result-name">-</dd>
+          <dt>分類</dt>
+          <dd id="result-category">-</dd>
+          <dt>說明</dt>
+          <dd id="result-description">-</dd>
+        </dl>
+        <details class="raw-json">
+          <summary>檢視原始 JSON</summary>
+          <div class="code-block">
+            <button type="button" class="btn btn--ghost btn--small code-block__copy" data-copy-target="result-raw">複製</button>
+            <pre><code id="result-raw"></code></pre>
+          </div>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <section class="section container" id="cli" aria-labelledby="cli-heading">
+    <div class="split">
+      <div>
+        <div class="section__header">
+          <h2 id="cli-heading">命令列與 curl 範例</h2>
+          <p class="section__lede">同一份資料可以在終端機、腳本或 CI 流程中直接查詢，不需要另外申請金鑰。</p>
+        </div>
+
+        <p>若已安裝 <code>holidaybook</code> CLI：</p>
+        <div class="code-block">
+          <button type="button" class="btn btn--ghost btn--small code-block__copy" data-copy-target="cli-example-1">複製</button>
+          <pre><code id="cli-example-1">holidaybook 2025-07-20</code></pre>
+        </div>
+        <p class="sample-output__label">輸出：</p>
+        <pre class="sample-output">2025-07-20：放假
+類別：星期六、星期日</pre>
+
+        <p>加上 <code>--json</code> 取得機器可讀的輸出，方便串接腳本：</p>
+        <div class="code-block">
+          <button type="button" class="btn btn--ghost btn--small code-block__copy" data-copy-target="cli-example-2">複製</button>
+          <pre><code id="cli-example-2">holidaybook --json 2025-07-20</code></pre>
+        </div>
+        <p class="sample-output__label">輸出：</p>
+        <pre class="sample-output">{"date":"2025-07-20","isHoliday":true,"name":"","category":"星期六、星期日","description":""}</pre>
+
+        <p>沒有安裝 CLI 的話，直接用 <code>curl</code> 讀取靜態 JSON 也可以：</p>
+        <div class="code-block">
+          <button type="button" class="btn btn--ghost btn--small code-block__copy" data-copy-target="curl-example">複製</button>
+          <pre><code id="curl-example">curl -fsS https://holiday.gh.miniasp.com/2025-07-20.json</code></pre>
+        </div>
+      </div>
+
+      <div>
+        <div class="section__header">
+          <h2>給 AI 代理人的查詢慣例</h2>
+          <p class="section__lede">將日期代入路徑即可，不需要額外的驗證流程或請求標頭。</p>
+        </div>
+        <div class="code-block">
+          <button type="button" class="btn btn--ghost btn--small code-block__copy" data-copy-target="agent-example">複製</button>
+          <pre><code id="agent-example">GET https://holiday.gh.miniasp.com/{YYYY-MM-DD}.json
+
+isHoliday = 1 表示當天放假
+isHoliday = 0 表示當天正常上班、上課
+name、holidaycategory、description 可能為空字串</code></pre>
+        </div>
+        <p class="section__lede">建議代理人以 <code>isHoliday</code> 欄位為準，不要用「是否為週末」自行推算，因為補班日與國定假日調整都會覆寫一般的週末規則。CLI 的 <code>--json</code> 會把同一份資料正規化成 <code>date</code>（<code>YYYY-MM-DD</code>）、布林值 <code>isHoliday</code> 與 <code>category</code>；直接讀取靜態 JSON 時則是 <code>YYYYMMDD</code>、<code>0</code>／<code>1</code> 與 <code>holidaycategory</code>。</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="section container" id="api" aria-labelledby="api-heading">
+    <div class="section__header">
+      <h2 id="api-heading">API 說明（機器可讀）</h2>
+      <p class="section__lede">單日、單月、單年三種路徑共用同一個資料結構；月與年的回應是物件陣列。</p>
+    </div>
+
+    <dl class="endpoint-list">
+      <dt>單日</dt>
+      <dd><code>/{YYYY-MM-DD}.json</code> 例如 <code>/2025-07-20.json</code></dd>
+      <dt>單月</dt>
+      <dd><code>/{YYYY-MM}.json</code> 例如 <code>/2025-07.json</code></dd>
+      <dt>單年</dt>
+      <dd><code>/{YYYY}.json</code> 例如 <code>/2025.json</code></dd>
+    </dl>
+
+    <table class="field-table">
+      <caption>單日 JSON 欄位</caption>
+      <thead>
+        <tr>
+          <th scope="col">欄位</th>
+          <th scope="col">型別</th>
+          <th scope="col">說明</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>date</code></td>
+          <td>string</td>
+          <td>日期，格式為 <code>YYYYMMDD</code>。</td>
+        </tr>
+        <tr>
+          <td><code>isHoliday</code></td>
+          <td>0 或 1</td>
+          <td>1 表示放假，0 表示正常上班上課。請直接採用此值，不要自行以星期幾推算。</td>
+        </tr>
+        <tr>
+          <td><code>name</code></td>
+          <td>string</td>
+          <td>國定假日或紀念日名稱，平日與例假日通常為空字串。</td>
+        </tr>
+        <tr>
+          <td><code>holidaycategory</code></td>
+          <td>string</td>
+          <td>假期分類，例如「星期六、星期日」或「放假之紀念日及節日」。</td>
+        </tr>
+        <tr>
+          <td><code>description</code></td>
+          <td>string</td>
+          <td>補充說明，可能為空字串。</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>需要留意的例外</h3>
+    <ul class="remark-list">
+      <li>軍人節只有軍人放假，本資料將它標記為非假日（<code>isHoliday: 0</code>）。</li>
+      <li>勞動節只有勞工放假，一般行政機關與學校照常上班上課。</li>
+      <li>補班日會顯示為正常上班日，即使落在週六、週日。</li>
+      <li>超出來源日曆表已公告範圍的日期（通常是尚未公告的年度），會先以正常上班日呈現，實際放假規則仍以政府公告為準。</li>
+    </ul>
+  </section>
+
+</main>
+
+<footer class="site-footer">
+  <div class="container site-footer__inner">
+    <p>資料來源：<a href="https://data.taipei/dataset/detail?id=c30ca421-d935-4faa-b523-9c175c8de738">臺北市政府行政機關辦公日曆表</a>，經 GitHub Actions 每日重新產生。</p>
+    <p><a href="https://github.com/doggy8088/holidaybook">原始碼與議題回報</a></p>
+  </div>
+</footer>
+
+<script src="app.js" defer></script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,676 @@
+/*
+  Taiwan Holiday Lookup stylesheet
+  Design system: one blue-green accent, consistent radius scale, no gradients/glows.
+*/
+
+:root {
+  color-scheme: light dark;
+
+  --bg: #f6f4ef;
+  --surface: #ffffff;
+  --surface-sunken: #edeae2;
+  --text: #1c211f;
+  --text-muted: #52605a;
+  --border: #d9d3c6;
+  --border-strong: #b9b2a1;
+  --accent: #0d7a68;
+  --accent-strong: #095b4d;
+  --accent-contrast: #ffffff;
+  --accent-tint: #e2f1ec;
+  --danger: #9b2c2c;
+  --danger-tint: #fbe9e9;
+  --focus-ring: #0d7a68;
+
+  --radius-sm: 4px;
+  --radius-md: 10px;
+  --radius-lg: 18px;
+
+  --font-display: "Iowan Old Style", "Palatino Linotype", Georgia, "Noto Serif TC", serif;
+  --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang TC", "Microsoft JhengHei", Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+
+  --duration: 160ms;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0c1210;
+    --surface: #141c19;
+    --surface-sunken: #0e1513;
+    --text: #e9efec;
+    --text-muted: #9db3ac;
+    --border: #253531;
+    --border-strong: #34483f;
+    --accent: #3ecbb0;
+    --accent-strong: #6fe0c9;
+    --accent-contrast: #04231d;
+    --accent-tint: #12312a;
+    --danger: #f0a6a6;
+    --danger-tint: #3a1616;
+    --focus-ring: #3ecbb0;
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-body);
+  line-height: 1.55;
+  font-size: 1rem;
+}
+
+img,
+svg {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: var(--accent-strong);
+}
+
+@media (prefers-color-scheme: dark) {
+  a {
+    color: var(--accent-strong);
+  }
+}
+
+a:hover {
+  text-decoration-thickness: 2px;
+}
+
+:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: -3rem;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  z-index: 100;
+  transition: top var(--duration) ease-out;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.skip-link:focus {
+  top: 1rem;
+}
+
+.container {
+  width: 100%;
+  max-width: 74rem;
+  margin-inline: auto;
+  padding-inline: var(--space-5);
+}
+
+/* ---------- Header ---------- */
+
+.site-header {
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.site-header__inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-block: var(--space-4);
+}
+
+.brand {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  text-decoration: none;
+  color: inherit;
+}
+
+.brand__mark {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.brand__tagline {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.site-nav ul {
+  display: flex;
+  gap: var(--space-5);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 0.92rem;
+}
+
+.site-nav a {
+  text-decoration: none;
+  color: var(--text-muted);
+  padding-block: var(--space-1);
+  border-bottom: 2px solid transparent;
+}
+
+.site-nav a:hover,
+.site-nav a:focus-visible {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+}
+
+/* ---------- Hero / query tool ---------- */
+
+.hero {
+  padding-block: var(--space-7) var(--space-6);
+}
+
+.hero__intro {
+  max-width: 42rem;
+  margin-bottom: var(--space-6);
+}
+
+.hero__eyebrow {
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent-strong);
+  font-weight: 700;
+  margin: 0 0 var(--space-2);
+}
+
+.hero h1 {
+  font-family: var(--font-display);
+  font-size: clamp(1.9rem, 4vw, 2.75rem);
+  line-height: 1.15;
+  margin: 0 0 var(--space-3);
+}
+
+.hero p.hero__lede {
+  color: var(--text-muted);
+  font-size: 1.05rem;
+  margin: 0;
+}
+
+.query-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.query-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: var(--space-4);
+}
+
+.query-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex: 1 1 12rem;
+}
+
+.query-form__field label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.date-step {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+input[type="date"],
+input[type="text"] {
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--text);
+  width: 100%;
+}
+
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.6rem;
+  height: 2.6rem;
+  flex: 0 0 auto;
+  border: 1px solid var(--border-strong);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.icon-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.btn {
+  font: inherit;
+  font-weight: 700;
+  padding: 0.7rem 1.4rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--accent-contrast);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.btn:hover {
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--text);
+  border-color: var(--border-strong);
+  font-weight: 600;
+}
+
+.btn--ghost:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.btn--small {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.82rem;
+  border-radius: var(--radius-sm);
+}
+
+.query-form__actions {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.quick-dates {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+
+/* ---------- Result panel ---------- */
+
+.result {
+  margin-top: var(--space-5);
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-5);
+  min-height: 6rem;
+}
+
+.result__state {
+  display: none;
+}
+
+.result[data-state="idle"] .result__state--idle,
+.result[data-state="loading"] .result__state--loading,
+.result[data-state="error"] .result__state--error,
+.result[data-state="empty"] .result__state--empty,
+.result[data-state="success"] .result__state--success {
+  display: block;
+}
+
+.result__state--loading {
+  color: var(--text-muted);
+}
+
+.spinner {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid var(--border-strong);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  margin-inline-end: var(--space-2);
+  vertical-align: -2px;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.notice {
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  font-size: 0.95rem;
+}
+
+.notice--error {
+  background: var(--danger-tint);
+  color: var(--danger);
+  border: 1px solid var(--danger);
+}
+
+.notice--empty {
+  background: var(--surface-sunken);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+
+.status-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.status-date {
+  font-family: var(--font-mono);
+  font-size: 1.05rem;
+  color: var(--text-muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-weight: 700;
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.92rem;
+  border: 1px solid transparent;
+}
+
+.badge--holiday {
+  background: var(--accent-tint);
+  color: var(--accent-strong);
+  border-color: var(--accent);
+}
+
+.badge--workday {
+  background: var(--surface-sunken);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+.result-detail {
+  display: grid;
+  grid-template-columns: 6rem 1fr;
+  gap: var(--space-2) var(--space-4);
+  font-size: 0.96rem;
+}
+
+.result-detail dt {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.result-detail dd {
+  margin: 0;
+}
+
+.raw-json {
+  margin-top: var(--space-4);
+}
+
+.raw-json summary {
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.raw-json pre {
+  margin-top: var(--space-2);
+}
+
+/* ---------- Code blocks ---------- */
+
+pre {
+  background: var(--surface-sunken);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+  line-height: 1.6;
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+}
+
+:not(pre) > code {
+  background: var(--surface-sunken);
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--radius-sm);
+}
+
+.code-block {
+  position: relative;
+  margin: var(--space-3) 0 var(--space-5);
+}
+
+.code-block pre {
+  padding-right: 5.5rem;
+}
+
+.code-block__copy {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+}
+
+.sample-output__label {
+  margin: 0 0 var(--space-2);
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.sample-output {
+  margin: 0 0 var(--space-5);
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ---------- Sections ---------- */
+
+.section {
+  padding-block: var(--space-6);
+  border-top: 1px solid var(--border);
+}
+
+.section__header {
+  max-width: 40rem;
+  margin-bottom: var(--space-5);
+}
+
+.section h2 {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  margin: 0 0 var(--space-2);
+}
+
+.section__lede {
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.split {
+  display: grid;
+  gap: var(--space-6);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 62rem) {
+  .split {
+    grid-template-columns: 3fr 2fr;
+    align-items: start;
+  }
+}
+
+.field-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.field-table caption {
+  text-align: left;
+  color: var(--text-muted);
+  margin-bottom: var(--space-2);
+  font-size: 0.85rem;
+}
+
+.field-table th,
+.field-table td {
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.field-table th {
+  color: var(--text-muted);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.field-table code {
+  white-space: nowrap;
+}
+
+.endpoint-list {
+  list-style: none;
+  margin: 0 0 var(--space-5);
+  padding: 0;
+  display: grid;
+  grid-template-columns: minmax(5rem, auto) 1fr;
+  gap: var(--space-2) var(--space-3);
+  align-items: baseline;
+  font-size: 0.92rem;
+}
+
+.endpoint-list dt {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.endpoint-list dd {
+  margin: 0;
+}
+
+.remark-list {
+  padding-left: 1.2rem;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+.remark-list li + li {
+  margin-top: var(--space-2);
+}
+
+noscript .notice {
+  display: block;
+  margin-bottom: var(--space-5);
+}
+
+/* ---------- Footer ---------- */
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding-block: var(--space-6);
+  color: var(--text-muted);
+  font-size: 0.86rem;
+}
+
+.site-footer__inner {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.site-footer a {
+  color: var(--text-muted);
+}
+
+.site-footer a:hover,
+.site-footer a:focus-visible {
+  color: var(--accent-strong);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+@media (max-width: 30rem) {
+  .container {
+    padding-inline: var(--space-4);
+  }
+
+  .query-card {
+    padding: var(--space-4);
+  }
+
+  .result-detail {
+    grid-template-columns: 5.5rem 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## 摘要

- 新增 Go 1.23 `holidaybook` CLI，透過既有靜態 JSON API 查詢台灣指定日期，提供人類可讀與穩定的 `--json` 輸出。
- 新增可分享的 repository agent skill，定義嚴格日期驗證、CLI 優先與安全的 `curl` 備援流程。
- 建立 macOS、Linux、Windows 的 amd64/arm64 發布設定、安裝器、checksum 驗證與 PR CI。
- 新增不需前端建置的公開查詢網站，並將網站與既有 `docs/*.json` 組裝為同一份 GitHub Pages 內容。
- 強化每日資料產生、失敗通知與 Pages 部署流程，並完整更新使用與維運文件。

## 主要行為與介面

- CLI：`holidaybook YYYY-MM-DD`，支援 `--json`、`--base-url`、`--timeout`、`--version`、`--help`，旗標可置於日期前後。
- 成功結束碼為 `0`、參數錯誤為 `2`、執行期錯誤為 `1`；JSON 錯誤提供可機器判讀的 `error.code`。
- CLI 將靜態 API 的 `YYYYMMDD`、`0/1`、`holidaycategory` 正規化為 `YYYY-MM-DD`、布林值與 `category`，並驗證回應日期及必要欄位。
- Agent skill 位於 `.github/skills/query-taiwan-holiday`：優先呼叫 `holidaybook --json`，CLI 不存在時才使用 HTTPS `curl`；不以週末規則猜測，也不替換失敗日期。
- 公開網站支援日期輸入、前後日、今天／明天／下週快速查詢、網址 `date` 參數、複製範例、請求取消、資料完整性檢查及無障礙狀態提示。

## 安裝與 Release 資產契約

- `install.sh` 支援 macOS/Linux，`install.ps1` 支援 Windows；皆可安裝 latest 或指定 `vX.Y.Z`，並可自訂安裝目錄。
- GoReleaser 契約為六組資產：
  - `holidaybook_darwin_amd64.tar.gz`
  - `holidaybook_darwin_arm64.tar.gz`
  - `holidaybook_linux_amd64.tar.gz`
  - `holidaybook_linux_arm64.tar.gz`
  - `holidaybook_windows_amd64.zip`
  - `holidaybook_windows_arm64.zip`
- 每次 Release 同時產出 `checksums.txt`（SHA-256）；兩套安裝器在替換執行檔前都會下載並驗證對應 checksum。
- Release 為 tag-driven：只有推送符合 `v*` 的 tag 才會執行 `.github/workflows/release.yml`，先跑 Go 測試，再由 GoReleaser 建立 GitHub Release。此 PR 不代表 Release 已經發布。

## Pages 與自訂網域行為

- `deploy-pages.yml` 會在 `master` 的 `public/**`、`docs/*.json` 或工作流程本身變更後，把 `public/` 與 `docs/` 頂層 JSON 組裝至 `_site/`，並驗證首頁及 `CNAME` 後部署。
- `public/CNAME` 設定為 `holiday.gh.miniasp.com`；該網域只有在本 PR 合併、Pages 完成部署，且 repository Pages 自訂網域/DNS/HTTPS 設定完成後才會正式上線。
- 在上述 rollout 完成前，既有 Pages 子路徑 `https://doggy8088.github.io/holidaybook` 仍是驗證用 fallback，也可透過 CLI 的 `--base-url` 指向該路徑。
- 本 PR 不宣稱 production Pages 或自訂網域目前已部署完成。

## 驗證證據

已完成以下驗證：

- Go 格式、測試與靜態分析：`gofmt`、`go test ./...`、`go vet ./...`。
- 六組交叉建置：Darwin/Linux/Windows × amd64/arm64。
- GoReleaser：`goreleaser check` 與 snapshot release。
- 安裝器：POSIX 與 PowerShell 安裝器檢查，包含語法、資產命名與 checksum 流程。
- GitHub Actions 與 shell：`actionlint`、`shellcheck`。
- Agent skill：技能結構、中繼資料與內容驗證。
- 靜態網站：HTML/CSS/JavaScript、查詢流程、相對 JSON 路徑、CNAME 與 Pages 組站檢查。
- .NET：Release build、全部 7 項 xUnit 測試、執行產生器，並驗證產出 1761 個檔案及日/月/年 JSON。
- 差異衛生：`git diff --check` 無錯誤、工作樹乾淨，且分支與遠端 head 一致。

## Rollout 注意事項

1. 合併至 `master` 後，先觀察 PR CI 對應的 master push 執行結果。
2. 確認 Pages workflow 成功組站與部署，再於 repository Pages 設定自訂網域、DNS CNAME 與 HTTPS。
3. 以既有 Pages 子路徑及 `--base-url` 驗證網站與 CLI 查詢，再切換/確認 `holiday.gh.miniasp.com`。
4. 準備正式 CLI 版本時，再建立並推送帶註解的 `v*` tag；屆時才會建立 Release 與六組平台資產。
5. 確認 `PAT`、SendGrid 等選用 secrets 是否依維運需求設定；未設定 PAT 時，資料 workflow 使用 `GITHUB_TOKEN` 推送不會自動觸發後續 Pages workflow。

## 五個聚焦的繁中提交

1. `9338e66` — `feat(cli): 新增台灣假日查詢命令列工具`
2. `6ddd469` — `feat(skill): 提供可分享的台灣假日查詢技能`
3. `257c7cd` — `feat(web): 建立台灣假日速查靜態網站`
4. `651fa66` — `ci(release): 建立跨平台安裝發布與部署流程`
5. `7e5de89` — `docs(readme): 完整說明網站 CLI 技能與發布流程`

## Checklist

- [x] Go CLI 行為、錯誤介面與測試完成
- [x] 可分享 Agent Skill 與 metadata 完成
- [x] 六平台/架構組合、GoReleaser 與 checksum 契約完成
- [x] macOS/Linux/Windows 安裝器完成並驗證
- [x] 公開查詢網站與 Pages 組站流程完成
- [x] .NET 既有產生器建置、7 項測試與 1761 檔案產生驗證通過
- [x] 五個聚焦繁中提交，diff hygiene 通過
- [ ] 合併後完成 Pages 自訂網域/DNS/HTTPS 設定
- [ ] 發布版本時推送 `v*` tag 並驗證實際 Release 資產