### PR TITLE
feat(web): 新增顯眼的「一行指令安裝」區塊與對應的靜態契約檢查

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -88,6 +88,7 @@
       <ul>
         <li><a href="#lookup">查詢</a></li>
         <li><a href="#data">資料</a></li>
+        <li><a href="#install">安裝</a></li>
         <li><a href="#cli">CLI</a></li>
         <li><a href="#api">API</a></li>
         <li><a href="https://github.com/doggy8088/holidaybook">GitHub</a></li>
@@ -218,6 +219,43 @@
           <dt>取用條件</dt>
           <dd>純靜態 JSON 檔案，免註冊、免金鑰，網址可直接分享。</dd>
         </dl>
+      </div>
+    </div>
+  </section>
+
+  <section class="section section--install" id="install" aria-labelledby="install-heading">
+    <div class="container">
+      <div class="section__header">
+        <p class="section__kicker">安裝 CLI</p>
+        <h2 id="install-heading">一行指令安裝</h2>
+        <p class="section__lede">複製下面對應你系統的那一行貼進終端機就可以了。隨附的安裝腳本會自動判斷平台與 CPU 架構、從 GitHub Releases 取得對應的執行檔，並比對官方的 <code>checksums.txt</code> 驗證 SHA-256；雜湊不符就會中止安裝。</p>
+      </div>
+
+      <div class="install-grid">
+        <article class="install-card">
+          <h3 class="install-card__os" id="install-posix-label">macOS ／ Linux</h3>
+          <p class="install-card__note">使用 <code>install.sh</code>，自動判斷作業系統（macOS／Linux）與架構（amd64／arm64）。</p>
+          <div class="code-block code-block--install">
+            <button type="button" class="btn btn--ghost btn--small code-block__copy" data-copy-target="install-posix">複製</button>
+            <pre tabindex="0" role="group" aria-labelledby="install-posix-label"><code id="install-posix">curl -fsSL https://raw.githubusercontent.com/doggy8088/holidaybook/master/install.sh | sh</code></pre>
+          </div>
+          <p class="install-card__target">預設安裝到 <code>~/.local/bin</code>。</p>
+        </article>
+
+        <article class="install-card">
+          <h3 class="install-card__os" id="install-powershell-label">Windows（PowerShell）</h3>
+          <p class="install-card__note">使用 <code>install.ps1</code>，自動判斷架構（amd64／arm64）。</p>
+          <div class="code-block code-block--install">
+            <button type="button" class="btn btn--ghost btn--small code-block__copy" data-copy-target="install-powershell">複製</button>
+            <pre tabindex="0" role="group" aria-labelledby="install-powershell-label"><code id="install-powershell">irm https://raw.githubusercontent.com/doggy8088/holidaybook/master/install.ps1 | iex</code></pre>
+          </div>
+          <p class="install-card__target">預設安裝到 <code>%LOCALAPPDATA%\Programs\holidaybook</code>。</p>
+        </article>
+      </div>
+
+      <div class="install-footnote">
+        <p>不帶參數執行時安裝的是 <strong>latest release</strong>（目前為 <code>v1.0.0</code>）。腳本不會自動修改 <code>PATH</code>；安裝目錄若不在 <code>PATH</code> 中，腳本會在結束時提示你加入。</p>
+        <p>要指定版本、改安裝目錄，或想自己下載壓縮檔與 <code>checksums.txt</code> 手動安裝，請參考 <a href="https://github.com/doggy8088/holidaybook/releases" target="_blank" rel="noopener">GitHub Releases</a>；CLI 目前僅透過 Releases 發布，不提供 Homebrew、apt 或 winget 等套件管理員安裝方式。</p>
       </div>
     </div>
   </section>

--- a/public/styles.css
+++ b/public/styles.css
@@ -791,6 +791,111 @@ code,
   margin: 0;
 }
 
+/* ---------- One-command install ---------- */
+
+.section__kicker {
+  margin: 0 0 var(--space-3);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--jade);
+}
+
+.section--install {
+  background: var(--accent-tint);
+}
+
+.install-grid {
+  display: grid;
+  gap: var(--space-5);
+  grid-template-columns: 1fr;
+}
+
+/* Grid children default to min-width: auto, which would let the unbreakable
+   install URL stretch the track instead of scrolling inside the <pre>. */
+.install-grid > * {
+  min-width: 0;
+}
+
+.install-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: var(--space-5);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+}
+
+.install-card > * {
+  min-width: 0;
+}
+
+.install-card__os {
+  margin: 0 0 var(--space-2);
+  font-size: 1.02rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.install-card__note {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+.install-card .code-block--install {
+  margin: var(--space-4) 0 var(--space-3);
+}
+
+.install-card__target {
+  margin: auto 0 0;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+.install-footnote {
+  max-width: 52rem;
+  margin-top: var(--space-6);
+}
+
+.install-footnote p {
+  margin: 0 0 var(--space-3);
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+.install-footnote p:last-child {
+  margin-bottom: 0;
+}
+
+@media (min-width: 48rem) {
+  .install-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  /* Subgrid keeps the OS label, note, command and install path on the same
+     baselines across both cards even when the notes wrap differently. Browsers
+     without subgrid keep the flex column layout, which stays readable. */
+  @supports (grid-template-rows: subgrid) {
+    .install-grid {
+      grid-template-rows: repeat(4, auto);
+      row-gap: var(--space-3);
+    }
+
+    .install-card {
+      display: grid;
+      grid-row: span 4;
+      grid-template-rows: subgrid;
+    }
+
+    .install-card__target {
+      margin: 0;
+    }
+  }
+}
+
 /* Image-led civic story and image-supported CLI band. */
 
 .feature {
@@ -1046,6 +1151,11 @@ noscript .notice {
   }
 
   .quick-dates .btn--small {
+    min-height: 2.75rem;
+    padding-block: var(--space-2);
+  }
+
+  .code-block__copy {
     min-height: 2.75rem;
     padding-block: var(--space-2);
   }

--- a/scripts/check-public.mjs
+++ b/scripts/check-public.mjs
@@ -87,12 +87,24 @@ const NAMED_ENTITIES = {
   quot: '"',
 };
 
+const MAX_CODE_POINT = 0x10ffff;
+
+/* Only Unicode scalar values can be materialised: String.fromCodePoint throws a
+   RangeError above U+10FFFF, and lone surrogates would produce unusable text.
+   Anything else is left as written so a malformed reference surfaces as a normal
+   contract failure instead of crashing the whole check. */
+function fromCodePoint(value, original) {
+  if (!Number.isInteger(value) || value < 0 || value > MAX_CODE_POINT) return original;
+  if (value >= 0xd800 && value <= 0xdfff) return original;
+  return String.fromCodePoint(value);
+}
+
 function decodeEntities(source) {
   return source.replace(
     /&(?:#(\d+)|#[xX]([0-9a-fA-F]+)|([a-zA-Z][a-zA-Z0-9]*));/g,
     (match, decimal, hex, name) => {
-      if (decimal !== undefined) return String.fromCodePoint(Number(decimal));
-      if (hex !== undefined) return String.fromCodePoint(parseInt(hex, 16));
+      if (decimal !== undefined) return fromCodePoint(Number(decimal), match);
+      if (hex !== undefined) return fromCodePoint(parseInt(hex, 16), match);
       const decoded = NAMED_ENTITIES[name.toLowerCase()];
       return decoded === undefined ? match : decoded;
     },

--- a/scripts/check-public.mjs
+++ b/scripts/check-public.mjs
@@ -69,6 +69,18 @@ function hasThemeVariables(body) {
     new RegExp(`${property}\\s*:`, "i").test(body));
 }
 
+/* Install one-liners contain characters that must be escaped in HTML, so the
+   markup is compared against the real command rather than its entity form. */
+function decodeEntities(source) {
+  return source
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&nbsp;", " ")
+    .replaceAll("&amp;", "&");
+}
+
 const cname = readRequired("GitHub Pages CNAME", paths.cname);
 const html = readRequired("Page HTML", paths.html);
 const css = readRequired("Page stylesheet", paths.css);
@@ -152,14 +164,84 @@ check(
 
 const codeBlockCount = [...html.matchAll(/<div\b[^>]*\bclass=["'][^"']*\bcode-block\b[^"']*["'][^>]*>/gi)].length;
 const codePreMatches = [...html.matchAll(/<pre\b([^>]*)>\s*<code\b/gi)];
-check(codeBlockCount === 5, `Expected 5 .code-block elements, found ${codeBlockCount}.`);
-check(codePreMatches.length === 5, `Expected 5 code-block <pre> elements, found ${codePreMatches.length}.`);
+check(codeBlockCount === 7, `Expected 7 .code-block elements, found ${codeBlockCount}.`);
+check(codePreMatches.length === 7, `Expected 7 code-block <pre> elements, found ${codePreMatches.length}.`);
 codePreMatches.forEach((match, index) => {
   check(
     /\btabindex=["']0["']/i.test(match[1]),
     `Code-block <pre> ${index + 1} must include tabindex="0".`,
   );
 });
+
+/* The one-command install section is the primary conversion path for the CLI,
+   so its anchor, exact commands and copy wiring are pinned here rather than
+   left to a visual review. */
+check(
+  /<section\b[^>]*\bid=["']install["'][^>]*\baria-labelledby=["']install-heading["'][^>]*>/i.test(html),
+  'The page must contain <section id="install"> labelled by install-heading.',
+);
+check(
+  /<h2\b[^>]*\bid=["']install-heading["'][^>]*>/i.test(html),
+  'The install section must have an <h2 id="install-heading">.',
+);
+check(
+  /<nav\b[^>]*\bclass=["'][^"']*\bsite-nav\b[^"']*["'][^>]*>[\s\S]*?<a\b[^>]*\bhref=["']#install["'][^>]*>\s*安裝\s*<\/a>[\s\S]*?<\/nav>/i.test(html),
+  'The site navigation must link to #install with the label "安裝".',
+);
+
+const INSTALL_COMMANDS = [
+  {
+    id: "install-posix",
+    label: "macOS / Linux",
+    command: "curl -fsSL https://raw.githubusercontent.com/doggy8088/holidaybook/master/install.sh | sh",
+  },
+  {
+    id: "install-powershell",
+    label: "Windows PowerShell",
+    command: "irm https://raw.githubusercontent.com/doggy8088/holidaybook/master/install.ps1 | iex",
+  },
+];
+
+for (const { id, label, command } of INSTALL_COMMANDS) {
+  const codeMatch = html.match(new RegExp(`<code\\b[^>]*\\bid=["']${id}["'][^>]*>([\\s\\S]*?)</code>`, "i"));
+  check(Boolean(codeMatch), `The install section must contain <code id="${id}"> for ${label}.`);
+  if (codeMatch) {
+    check(
+      decodeEntities(codeMatch[1]).trim() === command,
+      `The ${label} install command must be exactly "${command}".`,
+    );
+  }
+
+  check(
+    new RegExp(`<button\\b[^>]*\\bdata-copy-target=["']${id}["'][^>]*>`, "i").test(html),
+    `The ${label} install command needs a copy button with data-copy-target="${id}".`,
+  );
+  const copyButton = html.match(new RegExp(`<button\\b([^>]*\\bdata-copy-target=["']${id}["'][^>]*)>`, "i"));
+  if (copyButton) {
+    check(
+      /\bclass=["'][^"']*\bcode-block__copy\b[^"']*["']/i.test(copyButton[1]),
+      `The ${label} copy button must reuse the .code-block__copy behaviour.`,
+    );
+  }
+
+  const preMatch = html.match(new RegExp(`<pre\\b([^>]*)>\\s*<code\\b[^>]*\\bid=["']${id}["']`, "i"));
+  check(Boolean(preMatch), `The ${label} command must live inside a <pre> element.`);
+  if (preMatch) {
+    check(
+      /\btabindex=["']0["']/i.test(preMatch[1]),
+      `The ${label} command block must be keyboard focusable with tabindex="0".`,
+    );
+  }
+}
+
+check(
+  /<a\b[^>]*\bhref=["']https:\/\/github\.com\/doggy8088\/holidaybook\/releases["'][^>]*>/i.test(html),
+  "The install section must link to https://github.com/doggy8088/holidaybook/releases for versioned or manual installs.",
+);
+check(
+  /SHA-256/i.test(html) && /checksums\.txt/i.test(html),
+  "The install section must state that the installer verifies the release SHA-256 against checksums.txt.",
+);
 
 const images = [...html.matchAll(/<img\b([^>]*)>/gi)].map((match) => match[1]);
 const attr = (source, name) => {
@@ -308,6 +390,17 @@ check(
   hasDeclaration(navLinkBody, "display", "inline-flex")
     && hasDeclaration(navLinkBody, "min-height", String.raw`2\.75rem`),
   "The scoped site navigation links must use inline-flex with min-height: 2.75rem.",
+);
+
+const copyButtonBody = ruleBody(responsiveMedia, String.raw`\.code-block__copy`);
+check(
+  hasDeclaration(copyButtonBody, "min-height", String.raw`2\.75rem`)
+    && hasDeclaration(
+      copyButtonBody,
+      "padding-block",
+      String.raw`(?:0?\.5rem|var\(\s*--space-2\s*\))`,
+    ),
+  "The scoped code-block copy buttons must set min-height: 2.75rem and 0.5rem block padding.",
 );
 
 if (errors.length > 0) {

--- a/scripts/check-public.mjs
+++ b/scripts/check-public.mjs
@@ -69,6 +69,27 @@ function hasThemeVariables(body) {
     new RegExp(`${property}\\s*:`, "i").test(body));
 }
 
+/* Returns the inner markup of the first matching element, tracking nesting of
+   the same tag so a scoped assertion cannot silently read past the element. */
+function elementBlock(source, tag, attributePattern) {
+  const opening = new RegExp(`<${tag}\\b(?=[^>]*\\b${attributePattern})[^>]*>`, "i");
+  const found = source.match(opening);
+  if (!found) return "";
+
+  const start = found.index + found[0].length;
+  const boundaries = new RegExp(`<${tag}\\b[^>]*>|</${tag}\\s*>`, "gi");
+  boundaries.lastIndex = start;
+  let depth = 1;
+  let match;
+
+  while ((match = boundaries.exec(source)) !== null) {
+    depth += match[0].startsWith("</") ? -1 : 1;
+    if (depth === 0) return source.slice(start, match.index);
+  }
+
+  return "";
+}
+
 /* Install one-liners contain characters that must be escaped in HTML, so the
    markup is compared against the real command rather than its entity form.
 
@@ -216,7 +237,9 @@ codePreMatches.forEach((match, index) => {
 
 /* The one-command install section is the primary conversion path for the CLI,
    so its anchor, exact commands and copy wiring are pinned here rather than
-   left to a visual review. */
+   left to a visual review. Everything the messages describe as belonging to the
+   install section is matched against that section only: the same link or wording
+   appearing elsewhere on the page must never mask a regression inside it. */
 check(
   hasAttributes("section", [
     String.raw`id=["']install["']`,
@@ -224,8 +247,14 @@ check(
   ]).test(html),
   'The page must contain <section id="install"> labelled by install-heading.',
 );
+
+const installSection = elementBlock(html, "section", String.raw`id=["']install["']`);
 check(
-  /<h2\b[^>]*\bid=["']install-heading["'][^>]*>/i.test(html),
+  installSection.length > 0,
+  'Could not read the contents of <section id="install">; is the closing tag missing?',
+);
+check(
+  /<h2\b[^>]*\bid=["']install-heading["'][^>]*>/i.test(installSection),
   'The install section must have an <h2 id="install-heading">.',
 );
 check(
@@ -247,7 +276,7 @@ const INSTALL_COMMANDS = [
 ];
 
 for (const { id, label, command } of INSTALL_COMMANDS) {
-  const codeMatch = html.match(new RegExp(`<code\\b[^>]*\\bid=["']${id}["'][^>]*>([\\s\\S]*?)</code>`, "i"));
+  const codeMatch = installSection.match(new RegExp(`<code\\b[^>]*\\bid=["']${id}["'][^>]*>([\\s\\S]*?)</code>`, "i"));
   check(Boolean(codeMatch), `The install section must contain <code id="${id}"> for ${label}.`);
   if (codeMatch) {
     check(
@@ -256,11 +285,11 @@ for (const { id, label, command } of INSTALL_COMMANDS) {
     );
   }
 
+  const copyButton = installSection.match(new RegExp(`<button\\b([^>]*\\bdata-copy-target=["']${id}["'][^>]*)>`, "i"));
   check(
-    new RegExp(`<button\\b[^>]*\\bdata-copy-target=["']${id}["'][^>]*>`, "i").test(html),
+    Boolean(copyButton),
     `The ${label} install command needs a copy button with data-copy-target="${id}".`,
   );
-  const copyButton = html.match(new RegExp(`<button\\b([^>]*\\bdata-copy-target=["']${id}["'][^>]*)>`, "i"));
   if (copyButton) {
     check(
       /\bclass=["'][^"']*\bcode-block__copy\b[^"']*["']/i.test(copyButton[1]),
@@ -268,7 +297,7 @@ for (const { id, label, command } of INSTALL_COMMANDS) {
     );
   }
 
-  const preMatch = html.match(new RegExp(`<pre\\b([^>]*)>\\s*<code\\b[^>]*\\bid=["']${id}["']`, "i"));
+  const preMatch = installSection.match(new RegExp(`<pre\\b([^>]*)>\\s*<code\\b[^>]*\\bid=["']${id}["']`, "i"));
   check(Boolean(preMatch), `The ${label} command must live inside a <pre> element.`);
   if (preMatch) {
     check(
@@ -279,11 +308,11 @@ for (const { id, label, command } of INSTALL_COMMANDS) {
 }
 
 check(
-  /<a\b[^>]*\bhref=["']https:\/\/github\.com\/doggy8088\/holidaybook\/releases["'][^>]*>/i.test(html),
+  /<a\b[^>]*\bhref=["']https:\/\/github\.com\/doggy8088\/holidaybook\/releases["'][^>]*>/i.test(installSection),
   "The install section must link to https://github.com/doggy8088/holidaybook/releases for versioned or manual installs.",
 );
 check(
-  /SHA-256/i.test(html) && /checksums\.txt/i.test(html),
+  /SHA-256/i.test(installSection) && /checksums\.txt/i.test(installSection),
   "The install section must state that the installer verifies the release SHA-256 against checksums.txt.",
 );
 

--- a/scripts/check-public.mjs
+++ b/scripts/check-public.mjs
@@ -70,15 +70,33 @@ function hasThemeVariables(body) {
 }
 
 /* Install one-liners contain characters that must be escaped in HTML, so the
-   markup is compared against the real command rather than its entity form. */
+   markup is compared against the real command rather than its entity form.
+
+   This is a true single pass: every reference is consumed by one regex match
+   and the replacement output is never rescanned. That ordering matters, because
+   chained replacements would mis-handle an escaped ampersand followed by an
+   entity name -- "&#38;amp;" is the HTML source for the literal text "&amp;",
+   not for "&". For the same reason "&amp;lt;" must decode to the literal text
+   "&lt;" and never to "<"; decoding it twice is the classic double-decode bug. */
+const NAMED_ENTITIES = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: " ",
+  quot: '"',
+};
+
 function decodeEntities(source) {
-  return source
-    .replaceAll("&lt;", "<")
-    .replaceAll("&gt;", ">")
-    .replaceAll("&quot;", '"')
-    .replaceAll("&#39;", "'")
-    .replaceAll("&nbsp;", " ")
-    .replaceAll("&amp;", "&");
+  return source.replace(
+    /&(?:#(\d+)|#[xX]([0-9a-fA-F]+)|([a-zA-Z][a-zA-Z0-9]*));/g,
+    (match, decimal, hex, name) => {
+      if (decimal !== undefined) return String.fromCodePoint(Number(decimal));
+      if (hex !== undefined) return String.fromCodePoint(parseInt(hex, 16));
+      const decoded = NAMED_ENTITIES[name.toLowerCase()];
+      return decoded === undefined ? match : decoded;
+    },
+  );
 }
 
 const cname = readRequired("GitHub Pages CNAME", paths.cname);

--- a/scripts/check-public.mjs
+++ b/scripts/check-public.mjs
@@ -83,7 +83,7 @@ const NAMED_ENTITIES = {
   apos: "'",
   gt: ">",
   lt: "<",
-  nbsp: " ",
+  nbsp: "\u00a0",
   quot: '"',
 };
 
@@ -187,8 +187,19 @@ if (themeBootstrap) {
   );
 }
 
+/* Attributes are matched with independent lookaheads so that reordering them --
+   which is semantically identical HTML -- cannot cause a false failure, while
+   every required attribute is still mandatory. */
+function hasAttributes(tag, attributes) {
+  const lookaheads = attributes.map((attribute) => `(?=[^>]*\\b${attribute})`).join("");
+  return new RegExp(`<${tag}\\b${lookaheads}[^>]*>`, "i");
+}
+
 check(
-  /<div\b[^>]*\bclass=["'][^"']*\bquick-dates\b[^"']*["'][^>]*\brole=["']group["'][^>]*>/i.test(html),
+  hasAttributes("div", [
+    String.raw`class=["'][^"']*\bquick-dates\b[^"']*["']`,
+    String.raw`role=["']group["']`,
+  ]).test(html),
   'The .quick-dates container must include role="group".',
 );
 
@@ -207,7 +218,10 @@ codePreMatches.forEach((match, index) => {
    so its anchor, exact commands and copy wiring are pinned here rather than
    left to a visual review. */
 check(
-  /<section\b[^>]*\bid=["']install["'][^>]*\baria-labelledby=["']install-heading["'][^>]*>/i.test(html),
+  hasAttributes("section", [
+    String.raw`id=["']install["']`,
+    String.raw`aria-labelledby=["']install-heading["']`,
+  ]).test(html),
   'The page must contain <section id="install"> labelled by install-heading.',
 );
 check(


### PR DESCRIPTION
## 摘要

網站有 CLI 章節，內文也寫著「安裝 CLI 會多一層正規化過的輸出」，但整個頁面從頭到尾**沒有任何一個地方告訴使用者怎麼安裝**。想裝 CLI 只能自己繞去 README 或 Releases 翻找——等於在最關鍵的轉換點上把人丟掉。導覽列也沒有安裝相關的錨點。

本 PR 新增顯眼的 **`#install`「一行指令安裝」** 區塊、導覽錨點，並把兩行安裝指令納入靜態契約檢查，避免日後被無聲改壞。

> 本 PR **尚未**部署到正式站。合併進 `master` 後才會由 `deploy-pages.yml` 觸發 GitHub Pages 部署。

基底：`master` @ `89a5533`（PR #24 的 merge commit）　·　共 5 個 commit　·　僅動 `public/index.html`、`public/styles.css`、`scripts/check-public.mjs`

**`public/app.js` 完全沒有修改** —— 新的複製按鈕沿用既有的 `data-copy-target` 契約，`document.querySelectorAll("[data-copy-target]")` 會自動接管。

---

## 一、導覽與區塊位置

- `.site-nav` 在「資料」與「CLI」之間加入 **`安裝`** 錨點，指向 `#install`。
- `#install` 放在 `#data` 與 `#cli` 之間，讓敘事順序成為「查詢 → 資料 → **安裝** → CLI → API」：使用者先理解資料是什麼，緊接著就看到怎麼把它裝進終端機。
- 區塊背景使用 `--accent-tint`，與前後兩段（`--bg-alt` / `--bg`）明顯區隔以達到「顯眼」的需求，同時仍是主題代幣而非硬編碼顏色。

## 二、兩行可直接複製執行的指令

| 卡片標題 | 指令 |
| --- | --- |
| **macOS ／ Linux** | `curl -fsSL https://raw.githubusercontent.com/doggy8088/holidaybook/master/install.sh \| sh` |
| **Windows（PowerShell）** | `irm https://raw.githubusercontent.com/doggy8088/holidaybook/master/install.ps1 \| iex` |

兩行都與 `README.md` **逐字相同**（已用程式比對確認原封不動出現於 README），兩個 raw 網址實測皆回 **HTTP 200**。

- 沿用既有的 `.code-block` / `.code-block__copy` 結構與 `data-copy-target="install-posix"` / `data-copy-target="install-powershell"`，因此連按防護與標籤還原行為一併沿用。
- 兩個 `<pre>` 都是 `tabindex="0"`，並以 `role="group"` + `aria-labelledby` 指向該卡片的作業系統標題，讓可捲動區域有明確名稱。
- 底部連到 **[GitHub Releases](https://github.com/doggy8088/holidaybook/releases)**，涵蓋「指定版本」與「手動下載壓縮檔與 `checksums.txt`」兩種進階需求。

## 三、文案準確性（刻意不誇大）

文案只描述安裝腳本**實際做得到**的事，逐項對照 `install.sh` 與 `install.ps1` 原始碼：

| 文案主張 | 對應實作 |
| --- | --- |
| 自動判斷平台與 CPU 架構 | `install.sh` 以 `uname -s` 判斷 macOS/Linux、`uname -m` 判斷 amd64/arm64 |
| （Windows 卡片只說判斷架構） | `install.ps1` **只判斷架構**，它本來就是 Windows 專用——兩張卡片說明**刻意寫得不一樣**，沒把「判斷作業系統」安到 PowerShell 腳本頭上 |
| 比對官方 `checksums.txt` 驗證 SHA-256，不符即中止 | POSIX 版依序試 `sha256sum`/`shasum`/`openssl`；PS 版用 `Get-FileHash -Algorithm SHA256`；不符即 `die`/`Stop-Installer` |
| 不帶參數安裝的是 latest release（目前為 `v1.0.0`） | 兩支腳本 `version` 預設值皆為 `latest`；刻意**不把指令寫死成 v1.0.0**，讓複製貼上的人永遠拿到最新版 |
| 腳本不會自動修改 `PATH` | 兩支腳本都只在結束時提示，不改寫任何 shell 設定檔——不講清楚使用者裝完會以為壞掉 |
| 預設安裝位置 `~/.local/bin`、`%LOCALAPPDATA%\Programs\holidaybook` | 與腳本預設值一致 |
| 僅透過 Releases 發布，不提供 Homebrew / apt / winget | 與 README 一致，避免使用者去找不存在的套件來源 |

## 四、版面與觸控目標

- `.install-grid` 在 48rem 以上切兩欄、以下單欄；`.install-grid > *` 與 `.install-card > *` 都設 `min-width: 0`，讓過長的安裝網址在 `<pre>` 內部捲動而不是撐開格線軌道。
- 兩欄時以 `grid-template-rows: subgrid` 讓兩張卡片的四列（OS 標題／說明／指令／安裝位置）對齊；包在 `@supports` 內，不支援 subgrid 的瀏覽器退回 flex 直排，仍完全可讀。
- **觸控目標修正**：實測發現 `.code-block__copy` 在手機上只有 **52×34**，低於本站既有的 44px 慣例（`.icon-btn`、`.quick-dates .btn--small`、`.site-nav a`、主題按鈕都已是 2.75rem）。既然「複製」是這一段最主要的操作，就把 `.code-block__copy` 一併納入觸控媒體查詢——**同時修好了原有的五個複製按鈕**，實測七個全部變成 52×44。

## 五、靜態契約檢查（新增 9 類斷言）

`scripts/check-public.mjs` 新增：`<section id="install">` 存在且由 `install-heading` 標示、導覽必須有 `href="#install"` 且文字為「安裝」、兩個 `<code>` 內容必須**逐字**等於指定指令（比對前先還原 HTML 實體，`&amp;` 這類跳脫不會造成假通過）、兩個複製按鈕必須存在對應 `data-copy-target` 且帶 `code-block__copy` 類別、兩個指令都必須包在 `tabindex="0"` 的 `<pre>` 裡、必須連到 Releases、頁面必須同時出現 `SHA-256` 與 `checksums.txt`、`.code-block__copy` 必須在觸控媒體查詢內設 `min-height: 2.75rem`，以及 `.code-block` 與 `<pre>` 數量由 5 改為 **7**。

新增 `decodeEntities()` 輔助函式，讓指令比對針對真正的指令字串。

## 六、驗證

### 反向驗證：12 種刻意退化，**全部被攔截**

移除導覽 `安裝` 錨點 · POSIX 網址換成別的網域 · `irm` 改成 `iwr` · 複製目標指到別的區塊 · 拿掉 PowerShell `<pre>` 的 tabindex · 移除 Releases 連結 · 區塊 id 改成 `setup` · 「驗證 SHA-256」改成「驗證完整性」 · 整段刪掉 PowerShell code-block · 複製按鈕拿掉 `code-block__copy` · POSIX 指令後偷加 `--version v0.9.0` · 移除 `.code-block__copy` 觸控規則。

### 真實瀏覽器（本機以 `deploy-pages.yml` 相同方式組出 `public/` + `docs/*.json`）

- **零水平溢位**：四種尺寸（390×844、768×1024、1024×768、1440×1000）× 明暗兩主題，`document.scrollWidth` 與視窗寬度完全相同；兩段指令都在 `<pre>` 內部捲動。
- **axe-core 4.12.1**（wcag2a/wcag2aa/wcag21a/wcag21aa/wcag22aa）掃描**八種組合**：**violations 0、incomplete 0、passes 34**。
- **鍵盤**：兩個 `<pre>` 皆可聚焦（`document.activeElement === pre`）並可內部捲動 0 → 404／366px，頁面寬度維持 390。
- **複製**：以真實點擊觸發兩個按鈕，標籤「複製」→「已複製」→ 還原；另以 `navigator.clipboard.writeText` 監聽驗證寫入字串**逐字等於**畫面上的指令。
- **對比（淺／深）**：OS 標題 7.94／7.61、說明 7.23／7.64、安裝位置 7.23／7.64、區塊小標 5.37／7.32、註腳 6.06／6.68、註腳連結 9.02／8.71、指令區塊 14.38／15.01——全數遠超 AA。
- **subgrid 對齊**：兩欄時兩張卡片四列的 `getBoundingClientRect().top` 完全相同、卡片等高 320px。
- **導覽**：390px 下六個連結皆 44px 高，導覽 `scrollWidth` 358 = `clientWidth`，頁首無溢位。
- `prefers-reduced-motion: reduce` 下卡片與按鈕 transition 皆降為 0。

### 既有回歸

`node --check public/app.js` ✅　`node --test tests/public-app.test.mjs` **17 passed / 0 failed** ✅　`node scripts/check-public.mjs` ✅

> 螢幕截圖已在本機逐一確認（1440 明／暗、390 明／暗），**未提交任何截圖或二進位產物**。

---

## 七、上線方式

- 合併後 `deploy-pages.yml` 會因 `public/**` 路徑條件觸發 Pages 部署。
- `generate-data.yml` 的路徑條件是 `StaticGenerator/**`，本 PR 未觸及，**不會**被觸發。
- **不需要新的 CLI release 或 tag**：本 PR 未動 `cmd/`、`internal/`、`install.sh`、`install.ps1` 或 `.goreleaser.yml`，`v1.0.0` 仍是唯一版本。

## 檢查清單

- [x] 導覽有明確的 `安裝` 錨點指向 `#install`
- [x] 文案說明可用一行指令安裝，並準確描述 OS／架構偵測、latest release 與 SHA-256 驗證（未誇大）
- [x] macOS／Linux 一行指令可直接執行，與 README／installer 逐字一致
- [x] Windows PowerShell 一行指令可直接執行，與 README 逐字一致
- [x] 兩段程式碼區塊可鍵盤聚焦捲動、有明確 OS 標籤、沿用既有複製行為與 `data-copy-target`
- [x] 響應式（單欄／雙欄）且明暗主題對比全數超過 AA
- [x] 連結到 GitHub Releases 說明指定版本與手動安裝
- [x] 靜態契約檢查斷言區塊、兩行指令逐字、複製目標與導覽錨點
- [x] 12 種退化情境反向驗證檢查器
- [x] axe 八種組合 violations 0 / incomplete 0
- [x] `public/app.js` 未修改
- [x] 未提交截圖或二進位產物；未建立任何新 tag／release
- [x] Copilot review 全數處理完畢（5 輪，最終 🟢 Approval recommended）
- [x] CI 全綠（9/9 通過、零 annotation），以 merge commit 合併
- [ ] 合併後確認 Pages 部署並驗證正式站


