### PR TITLE
chore(release): 發布 holidaytw 2.0.1 npm production 測試

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ curl -fsSL https://raw.githubusercontent.com/doggy8088/holidaybook/master/instal
 指定版本或安裝目錄（也可用環境變數 `HOLIDAYTW_INSTALL_DIR` 取代 `--dir`；舊的 `HOLIDAYBOOK_INSTALL_DIR` 仍可作為過渡別名，但 `HOLIDAYTW_INSTALL_DIR` 與 `--dir` 優先權較高）：
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/doggy8088/holidaybook/master/install.sh | sh -s -- --version v2.0.0 --dir "$HOME/bin"
+curl -fsSL https://raw.githubusercontent.com/doggy8088/holidaybook/master/install.sh | sh -s -- --version v2.0.1 --dir "$HOME/bin"
 ```
 
 已 clone 專案時，也可以直接在本機執行腳本：
@@ -46,7 +46,7 @@ curl -fsSL https://raw.githubusercontent.com/doggy8088/holidaybook/master/instal
 ```sh
 git clone https://github.com/doggy8088/holidaybook.git
 cd holidaybook
-sh install.sh --version v2.0.0 --dir "$HOME/bin"
+sh install.sh --version v2.0.1 --dir "$HOME/bin"
 ```
 
 安裝完成後，若安裝目錄已在 `PATH` 中，腳本會提示直接執行 `holidaytw --help`；否則會提示先把該目錄加入 `PATH`。可用 `holidaytw --version` 確認安裝成功。
@@ -64,7 +64,7 @@ irm https://raw.githubusercontent.com/doggy8088/holidaybook/master/install.ps1 |
 ```powershell
 git clone https://github.com/doggy8088/holidaybook.git
 cd holidaybook
-./install.ps1 -Version v2.0.0 -InstallDir "$HOME\bin"
+./install.ps1 -Version v2.0.1 -InstallDir "$HOME\bin"
 ```
 
 安裝完成後，若安裝目錄已在 `PATH` 中可直接執行 `holidaytw --help`；否則腳本會提示加入 `PATH`，或直接以完整路徑執行 `& "<InstallDir>\holidaytw.exe" --help`。可用 `holidaytw --version` 確認安裝成功。
@@ -208,11 +208,11 @@ go build -o holidaytw ./cmd/holidaytw   # 建置執行檔
 ## CI/CD
 
 - **PR CI 與 master push**（`.github/workflows/ci.yml`）：對 Pull Request、push 到 `master` 或手動觸發時執行 `gofmt` 格式檢查、`go test ./...`、`go vet ./...`、`install.sh` 語法檢查（`bash -n`）、`install.ps1` 語法檢查（PowerShell parser）、`goreleaser check`、macOS／Linux／Windows × amd64／arm64 六種組合的交叉建置，以及 `.NET` 產生器單元測試。
-- **發布**（`.github/workflows/release.yml`）：推送符合 `v*` 的 tag 時觸發，先跑 `go test ./...`，再用 [GoReleaser](.goreleaser.yml) 建置並發布 GitHub Release，產出 macOS／Linux／Windows（amd64／arm64）共 6 組壓縮檔（`holidaytw_<os>_<arch>.tar.gz`，Windows 為 `.zip`）與 `checksums.txt`（SHA-256），`install.sh`／`install.ps1` 都會下載並驗證這份 checksum。維護者發布新版時，建立並推送一個帶註解的 tag 即可觸發；v1.0.0 是舊執行檔名稱 `holidaybook` 最後一版，往後（`v2.0.0` 起）發布的都是更名後的 `holidaytw`；以下以尚未發布的下一個主版本 `v2.0.0` 為例：
+- **發布**（`.github/workflows/release.yml`）：推送符合 `v*` 的 tag 時觸發，先跑 `go test ./...`，再用 [GoReleaser](.goreleaser.yml) 建置並發布 GitHub Release，產出 macOS／Linux／Windows（amd64／arm64）共 6 組壓縮檔（`holidaytw_<os>_<arch>.tar.gz`，Windows 為 `.zip`）與 `checksums.txt`（SHA-256），`install.sh`／`install.ps1` 都會下載並驗證這份 checksum。維護者發布新版時，建立並推送一個帶註解的 tag 即可觸發；v1.0.0 是舊執行檔名稱 `holidaybook` 最後一版，往後（`v2.0.0` 起）發布的都是更名後的 `holidaytw`；以下以目前的 patch release `v2.0.1` 為例：
 
   ```sh
-  git tag -a v2.0.0 -m "holidaytw v2.0.0"
-  git push origin v2.0.0
+  git tag -a v2.0.1 -m "holidaytw v2.0.1"
+  git push origin v2.0.1
   ```
 
 - **每日資料更新**（`.github/workflows/generate-data.yml`）：每天 UTC 02:00（台灣時間上午 10 點）以及手動觸發時執行，還原、建置、測試並執行 `StaticGenerator`，若 `docs/` 有變更就自動 commit 並 push；產生失敗時，若已設定 SendGrid 相關 secrets 會寄出通知信，並讓該次工作流程回報失敗。

--- a/npm/holidaytw/README.md
+++ b/npm/holidaytw/README.md
@@ -102,13 +102,13 @@ CLI exits non-zero with the same actionable error.
 ## Native binary version vs. npm package version
 
 The npm package's own `version` field (this package's semver, e.g.
-`2.0.0`) is intentionally **decoupled** from the native `holidaytw`
+`2.0.1`) is intentionally **decoupled** from the native `holidaytw`
 GitHub release tag it downloads. The native release tag is tracked
 separately in this package's `package.json` under
 `holidaytw.nativeVersion`. This means the npm package version can be
 bumped (including publishing a temporary prerelease such as
-`2.0.0-bootstrap.0`) without needing to change, or being constrained by,
-the native release tag being fetched (e.g. `v2.0.0`).
+temporary prerelease) without needing to change, or being constrained by,
+the native release tag being fetched (e.g. `v2.0.1`).
 
 ## Source and releases
 

--- a/npm/holidaytw/README.md
+++ b/npm/holidaytw/README.md
@@ -106,8 +106,8 @@ The npm package's own `version` field (this package's semver, e.g.
 GitHub release tag it downloads. The native release tag is tracked
 separately in this package's `package.json` under
 `holidaytw.nativeVersion`. This means the npm package version can be
-bumped (including publishing a temporary prerelease such as
-temporary prerelease) without needing to change, or being constrained by,
+bumped (including a temporary prerelease such as `2.0.1-rc.0`) without
+needing to change, or being constrained by,
 the native release tag being fetched (e.g. `v2.0.1`).
 
 ## Source and releases

--- a/npm/holidaytw/lib/config.js
+++ b/npm/holidaytw/lib/config.js
@@ -35,9 +35,8 @@ function validateNativeMetadata(nativeMeta) {
 // The native holidaytw release tag is intentionally read from a dedicated
 // package.json field (holidaytw.nativeVersion) instead of being derived
 // from the top-level npm "version". This decouples the npm package version
-// (which may be bumped independently, e.g. for prereleases such as
-// 2.0.0-bootstrap.0) from the native GitHub release tag that must be
-// downloaded (e.g. v2.0.0).
+// (which may be bumped independently, including temporary prereleases)
+// from the native GitHub release tag that must be downloaded.
 const {
   nativeVersion: NATIVE_VERSION,
   nativeRepository: NATIVE_REPOSITORY,

--- a/npm/holidaytw/package-lock.json
+++ b/npm/holidaytw/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "holidaytw",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "holidaytw",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "cpu": [
         "x64",
         "arm64"

--- a/npm/holidaytw/package.json
+++ b/npm/holidaytw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "holidaytw",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "npm launcher for the holidaytw Taiwan holiday CLI: downloads the matching native holidaytw binary from GitHub Releases and runs it.",
   "license": "UNLICENSED",
   "engines": {
@@ -30,9 +30,9 @@
     "pack:check": "node scripts/verify-pack.js"
   },
   "holidaytw": {
-    "nativeVersion": "2.0.0",
+    "nativeVersion": "2.0.1",
     "nativeRepository": "doggy8088/holidaybook",
-    "comment": "nativeVersion is the native holidaytw GitHub release tag (without the leading 'v') used for downloads. It is intentionally decoupled from the top-level npm 'version' field above so a temporary npm prerelease (e.g. 2.0.0-bootstrap.0) can still resolve and download native release v2.0.0."
+    "comment": "nativeVersion is the native holidaytw GitHub release tag (without the leading 'v') used for downloads. It is intentionally decoupled from the top-level npm 'version' field above so a temporary npm prerelease can still resolve and download an already-published native release."
   },
   "repository": {
     "type": "git",

--- a/npm/holidaytw/test/fixtures/bin/version-flaky
+++ b/npm/holidaytw/test/fixtures/bin/version-flaky
@@ -19,9 +19,9 @@ if (process.argv.includes('--version')) {
   fs.writeFileSync(counterFile, String(count));
 
   if (count === 1) {
-    process.stdout.write('holidaytw 2.0.0\n');
+    process.stdout.write('holidaytw 2.0.1\n');
   } else {
-    process.stdout.write('holidaytw 2.0.0-corrupted\n');
+    process.stdout.write('holidaytw 2.0.1-corrupted\n');
   }
   process.exit(0);
 }

--- a/npm/holidaytw/test/fixtures/bin/version-ok
+++ b/npm/holidaytw/test/fixtures/bin/version-ok
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // Prints the exact string the real native binary is expected to print
-// (see internal/cli/run.go), matching config.NATIVE_VERSION ("2.0.0")
+// (see internal/cli/run.go), matching config.NATIVE_VERSION ("2.0.1")
 // so it passes lib/installer.js's exact `--version` output check.
 if (process.argv.includes('--version')) {
-  process.stdout.write('holidaytw 2.0.0\n');
+  process.stdout.write('holidaytw 2.0.1\n');
   process.exit(0);
 }
 process.stdout.write(JSON.stringify(process.argv.slice(2)) + '\n');

--- a/npm/holidaytw/test/launch.test.js
+++ b/npm/holidaytw/test/launch.test.js
@@ -164,7 +164,7 @@ test('launch: performs a lazy install when the binary is missing, using a local 
       ...(isWindows ? { HOLIDAYTW_TEST_EXPECTED_VERSION: process.version } : {}),
     });
     assert.equal(code, 0, `expected exit 0, got stderr: ${stderr}`);
-    assert.equal(stdout.trim(), isWindows ? process.version : 'holidaytw 2.0.0');
+    assert.equal(stdout.trim(), isWindows ? process.version : 'holidaytw 2.0.1');
     assert.match(stderr, /installing now/);
   } finally {
     await close();

--- a/npm/holidaytw/test/packaging.test.js
+++ b/npm/holidaytw/test/packaging.test.js
@@ -117,7 +117,7 @@ function releaseEnv(baseUrl) {
   };
 }
 
-const expectedVersionOutput = IS_WINDOWS ? process.version : 'holidaytw 2.0.0';
+const expectedVersionOutput = IS_WINDOWS ? process.version : 'holidaytw 2.0.1';
 
 async function npmPack(destDir, caseDir) {
   const result = await runNpm(NPM_CLI, ['pack', '--silent', '--pack-destination', destDir, ...hermeticNpmArgs(caseDir)], {


### PR DESCRIPTION
## 目的\n\nTrusted Publishing 已完成設定，本 PR 將 holidaytw patch 版本提升至 2.0.1，建立一個可在 production 驗證 npm OIDC 發布的完整 release。\n\n## 變更\n\n- npm package 與 lockfile 更新至 2.0.1\n- nativeVersion 對齊 2.0.1，確保 GitHub Release 與 npm wrapper 嚴格驗證一致\n- 更新 npm 測試 fixture 與預期版本輸出\n- 更新固定版本安裝與 release 文件範例\n\n## 發布流程\n\n1. CI 通過後合併本 PR。\n2. 建立並推送 annotated `v2.0.1` tag，觸發六平台 GitHub Release。\n3. 等 Release assets 與 checksums 完成。\n4. 以 exact tag ref dispatch `publish-npm.yml`，由 Trusted Publishing 發布 npm `2.0.1`。\n5. 驗證 provenance、global install 與 npx。\n\n## 驗證\n\n- npm test：112/112\n- npm run pack:check：通過\n- go test ./...：通過\n- go vet ./...：通過\n- gofmt：通過\n- git diff --check：通過