### PR TITLE
ci: 消除 checkout 產生的 Git default-branch warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 permissions:
   contents: read
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -11,6 +11,11 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -10,6 +10,11 @@ on:
       - ".github/workflows/deploy-pages.yml"
   workflow_dispatch:
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/generate-data.yml
+++ b/.github/workflows/generate-data.yml
@@ -16,6 +16,11 @@ on:
       - "StaticGenerator/**"
       - ".github/workflows/generate-data.yml"
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 permissions:
   contents: write
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -46,6 +46,9 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
   PACKAGE_DIR: npm/holidaytw
   NATIVE_CLI_NAME: holidaytw
   REPO: doggy8088/holidaybook

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*"
 
+env:
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## 摘要

- 在所有使用 `actions/checkout` 的 workflow 注入 `init.defaultBranch=main` Git 設定。
- 消除 runner 執行 `git init` 時輸出的 default-branch warning hint。
- 保留 repository 實際預設分支 `master` 不變；設定只作用於 Actions runner 的暫時 checkout repository。

涵蓋 CI、GoReleaser release、Pages deploy、資料產生、npm Trusted Publishing 與 Copilot setup workflows。

## 驗證

- 以相同環境變數執行 `git init`，確認沒有 default-branch hint。
- Ruby YAML parser 解析全部 6 個 workflow 成功。
- `git diff --check` 通過。

目的：CI job 仍維持原有行為，但 logs 不再出現 warning hint。